### PR TITLE
use correct parameter for timeout on ping binary

### DIFF
--- a/sitebot/ngBot.tcl
+++ b/sitebot/ngBot.tcl
@@ -1058,7 +1058,7 @@ namespace eval ::ngBot {
 			foreach {desc ip port} $entrysplit {break}
 
 			if {[istrue $bnc(PING)]} {
-				if {[catch {exec $binary(PING) -c $bnc(PINGCOUNT) -t $bnc(TIMEOUT) $ip} reply]} {
+				if {[catch {exec $binary(PING) -c $bnc(PINGCOUNT) -W $bnc(TIMEOUT) $ip} reply]} {
 					set output "$theme(PREFIX)$announce(BNC_PING)"
 					set output [${ns}::replacevar $output "%num" $num]
 					set output [${ns}::replacevar $output "%desc" $desc]


### PR DESCRIPTION
Use the correct parameter for timeout on ping binary on linux.

`man ping`

```
       -t ttl
           ping only. Set the IP Time to Live.
       -W timeout
           Time to wait for a response, in seconds. The option affects only timeout in absence of any responses, otherwise ping waits for
           two RTTs.
```