### PR TITLE
Update Blow.tcl

### DIFF
--- a/sitebot/plugins/Blow.tcl
+++ b/sitebot/plugins/Blow.tcl
@@ -637,7 +637,7 @@ namespace eval ::ngBot::plugin::Blow {
 				if {[string equal [lindex $item 2] "+OK"]} {
 					continue
 				}
-				if {![string equal [lindex $item 1] "-|-"] && ![matchattr $handle [lindex $item 1] $target]} {
+				if {![string equal [lindex $item 1] "-|-"] && ![string equal [lindex $item 1] "*|*"] && ![matchattr $handle [lindex $item 1] $target]} {
 					continue
 				}
 				set blowEncryptedMessage 1


### PR DESCRIPTION
eggdrop 1.9.4 - changes:
Previously we formatted "ignore flags" as -|- but now format it as *|* for both the dcc command and the Tcl [binds] command.
Scripts having a special case for -|- instead of passing it to [matchattr] is justified because -|- wasn't allowed in [matchattr] in latest version of Eggdrop,
this pr works also for older versions of eggdrop.
