### PR TITLE
fail early if glftpd indicates transfer had problems

### DIFF
--- a/zipscript/src/zipscript-c.c
+++ b/zipscript/src/zipscript-c.c
@@ -173,7 +173,7 @@ main(int argc, char **argv)
 			if (allow_file_resume) {
 				d_log("zipscript-c: Broken xfer according to glftpd; ignoring because of allow_file_resume.\n");
 			} else {
-			switch (reason) {
+				switch (reason) {
 				 case 1:
 					d_log("zipscript-c: glftpd says transfer was aborted; exiting early.\n");
 					break;

--- a/zipscript/src/zipscript-c.c
+++ b/zipscript/src/zipscript-c.c
@@ -165,6 +165,32 @@ main(int argc, char **argv)
 		printf("Usage: %s --(full)config - shows (full) config compiled.\n\n", argv[0]);
 		exit(1);
 	}
+
+	/* introduced in glftpd 2.16 */
+	if (argc >= 5) {
+		int reason = atoi(argv[4]);
+		if (reason > 0 ) {
+			if (allow_file_resume) {
+				d_log("zipscript-c: Broken xfer according to glftpd; ignoring because of allow_file_resume.\n");
+			} else {
+			switch (reason) {
+				 case 1:
+					d_log("zipscript-c: glftpd says transfer was aborted; exiting early.\n");
+					break;
+				 case 2:
+					d_log("zipscript-c: glftpd says and error occured during transfer; exiting early.\n");
+					break;
+				 case 3:
+					d_log("zipscript-c: glftpd says disconnect/process was terminated during transfer; exiting early.\n");
+					break;
+				 default:
+					d_log("zipscript-c: glftpd indicates an unknown error (please update zipscript-c!); exiting early.\n");
+					break;
+				}
+				exit(EXIT_FAILURE);
+			}
+		}
+	}
         crc_arg = argv[3];
 #else
 	if (argc < 8) {

--- a/zipscript/src/zipscript-c.c
+++ b/zipscript/src/zipscript-c.c
@@ -174,16 +174,16 @@ main(int argc, char **argv)
 				d_log("zipscript-c: Broken xfer according to glftpd; ignoring because of allow_file_resume.\n");
 			} else {
 				switch (reason) {
-				 case 1:
+				case 1:
 					d_log("zipscript-c: glftpd says transfer was aborted; exiting early.\n");
 					break;
-				 case 2:
+				case 2:
 					d_log("zipscript-c: glftpd says an error occured during transfer; exiting early.\n");
 					break;
-				 case 3:
+				case 3:
 					d_log("zipscript-c: glftpd says disconnect/process was terminated during transfer; exiting early.\n");
 					break;
-				 default:
+				default:
 					d_log("zipscript-c: glftpd indicates an unknown error (please update zipscript-c!); exiting early.\n");
 					break;
 				}

--- a/zipscript/src/zipscript-c.c
+++ b/zipscript/src/zipscript-c.c
@@ -178,7 +178,7 @@ main(int argc, char **argv)
 					d_log("zipscript-c: glftpd says transfer was aborted; exiting early.\n");
 					break;
 				 case 2:
-					d_log("zipscript-c: glftpd says and error occured during transfer; exiting early.\n");
+					d_log("zipscript-c: glftpd says an error occured during transfer; exiting early.\n");
 					break;
 				 case 3:
 					d_log("zipscript-c: glftpd says disconnect/process was terminated during transfer; exiting early.\n");


### PR DESCRIPTION
Fail early if glftpd indicates the transfer had problems (and resume is not enabled)

Please use "Squash and merge".