### PR TITLE
rescan: fix potential vanishing of file ext after a strlcpy

### DIFF
--- a/zipscript/src/race-file.c
+++ b/zipscript/src/race-file.c
@@ -302,7 +302,7 @@ testfiles(struct LOCATIONS *locations, struct VARS *raceI, int rstatus)
 			remove_lock(raceI);
 			exit(EXIT_FAILURE);
 		}
-		ext = find_last_of(raceI->file.name, ".");
+		ext = find_last_of(rd.fname, ".");
 		if (*ext == '.')
 			ext++;
 		strlcpy(raceI->file.name, rd.fname, NAME_MAX);


### PR DESCRIPTION
In some cases, these lines are problematic in race-file.c:

```
		ext = find_last_of(raceI->file.name, ".");
		if (*ext == '.')
			ext++;
		strlcpy(raceI->file.name, rd.fname, NAME_MAX);
		
```		
In particular, strlcpy modifies raceI->file.name on which ext is based. This causes

```
			else if (rd.crc32 != 0 && strcomp(ignored_types, ext))
				rd.status = F_IGNORED;
```
rd.status to be set to IGNORED if say ext is empty, and the file is not handled correctly anymore.
This PR fixes this.