### PR TITLE
Refactoring and fixes of the locking mechanism

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 PZS-NG CHANGELOG
 ----------------
 
+v1.2.x  --> 1.2.1 :
+		- Refactored lock files including various fixes of closing files
+		- Removed some compile time errors
+
 v1.2.0  --> 1.2.x :
 		- Fix crash on freebsd (and perhaps others) in audiodirs (thanks to fated for reporting)
 		- Add some more strings to ignore in samplechecking, another subdir and sampledir

--- a/README.ZSCONFIG
+++ b/README.ZSCONFIG
@@ -1207,7 +1207,7 @@ message_group_header <STRING|DISABLED>
 
 message_header <STRING|DISABLED>
 	Define here what should be put in the top of the complete_message.
-	Default: ".-----------------====-------------------------== PZS-NG v1.2.0 ===--.\n"
+	Default: ".-----------------====-------------------------== PZS-NG v1.2.1 ===--.\n"
 
 message_audio <STRING|DISABLED>
 	Define here a special complete_message for audio-releases.

--- a/configGen/config.yaml
+++ b/configGen/config.yaml
@@ -1173,7 +1173,7 @@ options:
         can_disable: true
         comment: |-
             Define here what should be put in the top of the complete_message.
-        default: '".-----------------====-------------------------== PZS-NG v1.2.0 ===--.\n"' 
+        default: '".-----------------====-------------------------== PZS-NG v1.2.1 ===--.\n"'
 
     message_user_header:
         type: string

--- a/zipscript/include/race-file.h
+++ b/zipscript/include/race-file.h
@@ -67,5 +67,7 @@ extern void create_dirlist(const char *, char *, const int);
 extern int filebanned_match(const char *);
 extern int lenient_compare(char *, char *);
 extern int read_headdata(const char *);
+extern bool create_lock_link(struct VARS *);
+extern void remove_lock_link(struct VARS *);
 #endif
 

--- a/zipscript/include/race-file.h
+++ b/zipscript/include/race-file.h
@@ -1,6 +1,7 @@
 #ifndef _RACE_FILE_H_
 #define _RACE_FILE_H_
 
+#include <stdbool.h>
 #include <sys/stat.h>
 #include "objects.h"
 #include "zsfunctions.h"

--- a/zipscript/include/zsconfig.defaults.h
+++ b/zipscript/include/zsconfig.defaults.h
@@ -1002,7 +1002,7 @@
 
 #ifndef message_header
 #define message_header_is_defaulted
-#define message_header                            ".-----------------====-------------------------== PZS-NG v1.2.0 ===--.\n"
+#define message_header                            ".-----------------====-------------------------== PZS-NG v1.2.1 ===--.\n"
 #endif
 
 #ifndef message_store_in_mirror

--- a/zipscript/include/zsfunctions.h
+++ b/zipscript/include/zsfunctions.h
@@ -160,3 +160,4 @@ extern unsigned int insampledir(char *);
 #endif
 
 extern int _err_file_banned(const char *fn, struct VARS *v);
+extern void safe_snprintf(char *buffer, size_t size, const char *format, ...);

--- a/zipscript/include/zsfunctions.h
+++ b/zipscript/include/zsfunctions.h
@@ -2,6 +2,7 @@
 #define _ZSFUNCTIONS_H_
 
 #include <stdlib.h>
+#include <stdbool.h>
 #include <ctype.h>
 #include <stdio.h>
 #include <sys/types.h>
@@ -82,6 +83,7 @@ extern struct dirent **dirlist;
 extern unsigned int direntries;
 
 extern void	d_log(char *,...);
+extern void	d_log_ext(char *, char *,...);
 
 extern void	create_missing(char *);
 extern char    *findfileext(DIR *, char *);
@@ -161,3 +163,4 @@ extern unsigned int insampledir(char *);
 
 extern int _err_file_banned(const char *fn, struct VARS *v);
 extern void safe_snprintf(char *buffer, size_t size, const char *format, ...);
+extern bool is_process_running(pid_t pid);

--- a/zipscript/src/race-file.c
+++ b/zipscript/src/race-file.c
@@ -993,9 +993,9 @@ verify_racedata(const char *path, struct VARS *raceI)
 int
 create_lock(struct VARS *raceI, const char *path, unsigned int progtype, unsigned int force_lock, unsigned int queue)
 {
-	int		fd, cnt;
+	int			fd, cnt;
 	HEADDATA	hd;
-	struct stat	sp, sb;
+	struct stat	lock_stat, head_stat;
 	char		lockfile[PATH_MAX + 1];
 
 	/* this should really be moved out of the proc - we'll worry about it later */
@@ -1007,24 +1007,29 @@ create_lock(struct VARS *raceI, const char *path, unsigned int progtype, unsigne
 	}
 
 	snprintf(lockfile, PATH_MAX, "%s.lock", raceI->headpath);
-	if (!stat(lockfile, &sp) && (time(NULL) - sp.st_ctime >= max_seconds_wait_for_lock * 5))
+	if (!stat(lockfile, &lock_stat) && (time(NULL) - lock_stat.st_ctime >= max_seconds_wait_for_lock * 5)) {
 		unlink(lockfile);
+	}
+
 	cnt = 0;
+
 	while (cnt < 10 && link(raceI->headpath, lockfile)) {
 		cnt++;
 		d_log("create_lock: link failed (%d/10) - sleeping .1 seconds: %s\n", cnt, strerror(errno));
 		usleep(100000);
 	}
+
 	if (cnt == 10 ) {
 		close(fd);
 		d_log("create_lock: link failed: %s\n", strerror(errno));
 		return -1;
-	} else if (cnt)
+	} else if (cnt) {
 		d_log("create_lock: link ok.\n");
+	}
 
-	fstat(fd, &sb);
-	if (!sb.st_size) {
-		/* no lock file exists - let's create one with default values. */
+	fstat(fd, &head_stat);
+	if (!head_stat.st_size) {
+		/* no header file exists - let's create one with default values. */
 		hd.data_version = sfv_version;
 		raceI->data_type = hd.data_type = 0;
 		raceI->data_in_use = hd.data_in_use = progtype;
@@ -1035,104 +1040,117 @@ create_lock(struct VARS *raceI, const char *path, unsigned int progtype, unsigne
 		hd.data_pid = (unsigned int)getpid();
 		if (write(fd, &hd, sizeof(HEADDATA)) != sizeof(HEADDATA))
 			d_log("create_lock: write failed: %s\n", strerror(errno));
+		d_log("create_lock: lock set. (no previous head file found) pid: %d\n", hd.data_pid);
+
 		close(fd);
-		d_log("create_lock: lock set. (no previous lockfile found) pid: %d\n", hd.data_pid);
 		return 0;
-	} else {
-		if (read(fd, &hd, sizeof(HEADDATA)) == -1) {
-			d_log("create_lock: read() failed: %s\n", strerror(errno));
-		}
-		if (hd.data_version != sfv_version) {
-			d_log("create_lock: version of datafile mismatch. Stopping and suggesting a cleanup.\n");
-			close(fd);
-			unlink(lockfile);
-			return 1;
-		}
-		if ((time(NULL) - sb.st_ctime >= max_seconds_wait_for_lock * 5)) {
-			raceI->misc.release_type = hd.data_type;
-			raceI->data_in_use = hd.data_in_use = progtype;
-			raceI->data_incrementor = hd.data_incrementor = 1;
-			raceI->data_queue = hd.data_queue = 1;
-			hd.data_qcurrent = 0;
-			raceI->misc.data_completed = hd.data_completed;
-			hd.data_pid = (unsigned int)getpid();
-			lseek(fd, 0L, SEEK_SET);
-			if (write(fd, &hd, sizeof(HEADDATA)) != sizeof(HEADDATA))
-				d_log("create_lock: write failed: %s\n", strerror(errno));
-			close(fd);
-			d_log("create_lock: lock set. (lockfile exceeded max life time) pid: %d\n", hd.data_pid);
-			return 0;
-		}
-		if (hd.data_in_use) {						/* the lock is active */
-			if (force_lock == 2) {
-				raceI->data_queue = hd.data_queue = 1;
-				hd.data_qcurrent = 0;
-				d_log("create_lock: Unlock forced.\n");
-			} else {
-				if (force_lock == 3) {				/* we got a request to queue a lock if active */
-					raceI->data_queue = hd.data_queue;	/* we give the current queue number to the calling process */
-					hd.data_queue++;			/* we increment the number in the queue */
-					lseek(fd, 0L, SEEK_SET);
-					if (write(fd, &hd, sizeof(HEADDATA)) != sizeof(HEADDATA))
-						d_log("create_lock: write failed: %s\n", strerror(errno));
-					d_log("create_lock: lock active - putting you in queue. (%d/%d)\n", hd.data_qcurrent, hd.data_queue);
-				}
-				raceI->misc.release_type = hd.data_type;
-				raceI->misc.data_completed = hd.data_completed;
-				close(fd);
-				return hd.data_in_use;
-			}
-		}
-		if (!hd.data_in_use) {						/* looks like the lock is inactive */
-			if (force_lock == 2) {
-				raceI->data_queue = hd.data_queue = 1;
-				hd.data_qcurrent = 0;
-				d_log("create_lock: Unlock forced.\n");
-			} else if (force_lock == 3 && hd.data_queue > hd.data_qcurrent) {		/* we got a request to queue a lock if active, */
-										/* and there seems to be others in queue. Will not allow the */
-										/* process to lock, but wait for the queued process to do so. */
-				raceI->data_queue = hd.data_queue;		/* we give the queue number to the calling process */
-				hd.data_queue++;				/* we increment the number in the queue */
-				raceI->data_incrementor = hd.data_incrementor;
-				raceI->misc.release_type = hd.data_type;
-				raceI->misc.data_completed = hd.data_completed;
-				lseek(fd, 0L, SEEK_SET);
-				if (write(fd, &hd, sizeof(HEADDATA)) != sizeof(HEADDATA))
-					d_log("create_lock: write failed: %s\n", strerror(errno));
-				close(fd);
-				d_log("create_lock: putting you in queue. (%d/%d)\n", hd.data_qcurrent, hd.data_queue);
-				unlink(lockfile);
-				return -1;
-			} else if (hd.data_queue && (queue > hd.data_qcurrent) && !force_lock) {
-										/* seems there is a queue, and the calling process' place in */
-										/* the queue is still less than current. */
-				raceI->data_incrementor = hd.data_incrementor;	/* feed back the current incrementor */
-				raceI->misc.release_type = hd.data_type;
-				raceI->misc.data_completed = hd.data_completed;
-				close(fd);
-				unlink(lockfile);
-				return -1;
-			}
-		}
-		if (force_lock == 1) {						/* lock suggested - reseting the incrementor to 0 */
-			d_log("create_lock: Unlock suggested.\n");
-			hd.data_incrementor = 0;
-		} else {							/* either no lock and queue, or unlock is forced. */
-			hd.data_incrementor = 1;
-			hd.data_in_use = progtype;
-		}
-		raceI->data_incrementor = hd.data_incrementor;
-		raceI->misc.data_completed = hd.data_completed;
+	}
+
+	if (read(fd, &hd, sizeof(HEADDATA)) == -1) {
+		d_log("create_lock: read() failed: %s\n", strerror(errno));
+	}
+
+	if (hd.data_version != sfv_version) {
+		d_log("create_lock: version of datafile mismatch. Stopping and suggesting a cleanup.\n");
+		close(fd);
+		unlink(lockfile);
+		return 1;
+	}
+	
+	// the previous lock file age was old enough to claim the lock
+	if ((time(NULL) - head_stat.st_ctime >= max_seconds_wait_for_lock * 5)) {
 		raceI->misc.release_type = hd.data_type;
+		raceI->data_in_use = hd.data_in_use = progtype;
+		raceI->data_incrementor = hd.data_incrementor = 1;
+		raceI->data_queue = hd.data_queue = 1;
+		hd.data_qcurrent = 0;
+		raceI->misc.data_completed = hd.data_completed;
 		hd.data_pid = (unsigned int)getpid();
+
 		lseek(fd, 0L, SEEK_SET);
 		if (write(fd, &hd, sizeof(HEADDATA)) != sizeof(HEADDATA))
 			d_log("create_lock: write failed: %s\n", strerror(errno));
+		d_log("create_lock: lock set. (lockfile exceeded max life time) pid: %d\n", hd.data_pid);
+
 		close(fd);
-		raceI->data_in_use = progtype;
-		d_log("create_lock: lock set. pid: %d\n", hd.data_pid);
 		return 0;
 	}
+
+	if (force_lock == 2) {
+		raceI->data_queue = hd.data_queue = 1;
+		hd.data_qcurrent = 0;
+		d_log("create_lock: Unlock forced.\n");
+	} else if (hd.data_in_use) {			/* the lock is active */
+		
+		if (force_lock == 3) {				/* we got a request to queue a lock if active */
+			raceI->data_queue = hd.data_queue;	/* we give the current queue number to the calling process */
+			hd.data_queue++;			/* we increment the number in the queue */
+
+			lseek(fd, 0L, SEEK_SET);
+			if (write(fd, &hd, sizeof(HEADDATA)) != sizeof(HEADDATA))
+				d_log("create_lock: write failed: %s\n", strerror(errno));
+			d_log("create_lock: lock active - putting you in queue. (%d/%d)\n", hd.data_qcurrent, hd.data_queue);
+		}
+		raceI->misc.release_type = hd.data_type;
+		raceI->misc.data_completed = hd.data_completed;
+
+		// unlink(lockfile); NOT PRESENT but seems to be missing
+		close(fd);
+		return hd.data_in_use;
+	} else { 		/* looks like the lock is inactive */
+
+		/* We got a request to queue a lock	and there seems to be others in queue.
+		Will not allow the process to lock, but wait for the queued process to do so.
+		*/
+		if (force_lock == 3 && hd.data_queue > hd.data_qcurrent) {
+			raceI->data_queue = hd.data_queue;		/* we give the queue number to the calling process */
+			hd.data_queue++;				/* we increment the number in the queue */
+			raceI->data_incrementor = hd.data_incrementor;
+			raceI->misc.release_type = hd.data_type;
+			raceI->misc.data_completed = hd.data_completed;
+			lseek(fd, 0L, SEEK_SET);
+			if (write(fd, &hd, sizeof(HEADDATA)) != sizeof(HEADDATA))
+				d_log("create_lock: write failed: %s\n", strerror(errno));
+			d_log("create_lock: putting you in queue. (%d/%d)\n", hd.data_qcurrent, hd.data_queue);
+
+			unlink(lockfile);
+			close(fd);
+			return -1;				
+		} else if (force_lock == 0 && hd.data_queue && (queue > hd.data_qcurrent)) {
+									/* seems there is a queue, and the calling process' place in */
+									/* the queue is still less than current. */
+			raceI->data_incrementor = hd.data_incrementor;	/* feed back the current incrementor */
+			raceI->misc.release_type = hd.data_type;
+			raceI->misc.data_completed = hd.data_completed;
+
+			unlink(lockfile);
+			close(fd);
+			return -1;				
+		}
+	}
+
+	if (force_lock == 1) {				/* lock suggested - reseting the incrementor to 0 */
+		d_log("create_lock: Unlock suggested.\n");
+		hd.data_incrementor = 0;
+	} else {							/* either no lock and queue, or unlock is forced. */
+		hd.data_incrementor = 1;
+		hd.data_in_use = progtype;
+	}
+	
+	raceI->data_incrementor = hd.data_incrementor;
+	raceI->misc.data_completed = hd.data_completed;
+	raceI->misc.release_type = hd.data_type;
+	hd.data_pid = (unsigned int)getpid();
+
+	lseek(fd, 0L, SEEK_SET);
+	if (write(fd, &hd, sizeof(HEADDATA)) != sizeof(HEADDATA))
+		d_log("create_lock: write failed: %s\n", strerror(errno));
+	raceI->data_in_use = progtype;
+
+	d_log("create_lock: lock set. pid: %d\n", hd.data_pid);
+	close(fd);
+	return 0;
+
 }
 
 /* Remove the lock

--- a/zipscript/src/race-file.c
+++ b/zipscript/src/race-file.c
@@ -1003,7 +1003,7 @@ create_lock_link(struct VARS *raceI) {
 		usleep(100000);
 	}
 
-	if (cnt == 10 ) {
+	if (cnt == 10 && stat(lockfile, &lock_stat)) {
 		d_log("create_lock: link failed: %s\n", strerror(errno));
 		return false;
 	}

--- a/zipscript/src/race-file.c
+++ b/zipscript/src/race-file.c
@@ -1098,6 +1098,9 @@ create_lock(struct VARS *raceI, const char *path, unsigned int progtype, unsigne
 		return 0;
 	}
 
+	raceI->misc.release_type = hd.data_type;
+	raceI->misc.data_completed = hd.data_completed;
+
 	if (force_lock == 2) {
 		raceI->data_queue = hd.data_queue = 1;
 		hd.data_qcurrent = 0;
@@ -1114,8 +1117,6 @@ create_lock(struct VARS *raceI, const char *path, unsigned int progtype, unsigne
 			}
 			d_log("create_lock: lock active - putting you in queue. (%d/%d)\n", hd.data_qcurrent, hd.data_queue);
 		}
-		raceI->misc.release_type = hd.data_type;
-		raceI->misc.data_completed = hd.data_completed;
 
 		remove_lock_link(raceI);
 		close(fd);
@@ -1129,8 +1130,6 @@ create_lock(struct VARS *raceI, const char *path, unsigned int progtype, unsigne
 			raceI->data_queue = hd.data_queue;		/* we give the queue number to the calling process */
 			hd.data_queue++;				/* we increment the number in the queue */
 			raceI->data_incrementor = hd.data_incrementor;
-			raceI->misc.release_type = hd.data_type;
-			raceI->misc.data_completed = hd.data_completed;
 			lseek(fd, 0L, SEEK_SET);
 			if (write(fd, &hd, sizeof(HEADDATA)) != sizeof(HEADDATA)) {
 				d_log("create_lock: write failed: %s\n", strerror(errno));
@@ -1144,8 +1143,6 @@ create_lock(struct VARS *raceI, const char *path, unsigned int progtype, unsigne
 									/* seems there is a queue, and the calling process' place in */
 									/* the queue is still less than current. */
 			raceI->data_incrementor = hd.data_incrementor;	/* feed back the current incrementor */
-			raceI->misc.release_type = hd.data_type;
-			raceI->misc.data_completed = hd.data_completed;
 
 			remove_lock_link(raceI);			
 			close(fd);
@@ -1162,8 +1159,6 @@ create_lock(struct VARS *raceI, const char *path, unsigned int progtype, unsigne
 	}
 	
 	raceI->data_incrementor = hd.data_incrementor;
-	raceI->misc.data_completed = hd.data_completed;
-	raceI->misc.release_type = hd.data_type;
 	hd.data_pid = (unsigned int)getpid();
 
 	lseek(fd, 0L, SEEK_SET);

--- a/zipscript/src/race-file.c
+++ b/zipscript/src/race-file.c
@@ -202,7 +202,7 @@ delete_sfv(const char *path, struct VARS *raceI)
 	}
 
 	while (fread(&sd, sizeof(SFVDATA), 1, sfvfile)) {
-		snprintf(missing_fname, NAME_MAX, "%s-missing", sd.fname);
+		safe_snprintf(missing_fname, NAME_MAX, "%s-missing", sd.fname);
 		if ((f = findfilename(missing_fname, f, raceI)))
                 {
 			if (unlink(missing_fname) < 0)
@@ -984,15 +984,13 @@ verify_racedata(const char *path, struct VARS *raceI)
 	return 1;
 }
 
-
-
 bool 
 create_lock_link(struct VARS *raceI) {
 	int cnt;
 	char lockfile[PATH_MAX + 1];
 	struct stat lock_stat;
 
-	snprintf(lockfile, PATH_MAX, "%s.lock", raceI->headpath);
+	safe_snprintf(lockfile, sizeof(lockfile), raceI->headpath, "%s.lock");
 	if (!stat(lockfile, &lock_stat) && (time(NULL) - lock_stat.st_ctime >= max_seconds_wait_for_lock * 5)) {
 		unlink(lockfile);
 	}
@@ -1017,7 +1015,7 @@ create_lock_link(struct VARS *raceI) {
 void
 remove_lock_link(struct VARS *raceI) {
 	char lockfile[PATH_MAX + 1];
-	snprintf(lockfile, PATH_MAX, "%s.lock", raceI->headpath);
+	safe_snprintf(lockfile, sizeof(lockfile), raceI->headpath, "%s.lock");	
 	unlink(lockfile);
 }
 
@@ -1036,7 +1034,7 @@ create_lock(struct VARS *raceI, const char *path, unsigned int progtype, unsigne
 	struct stat	head_stat;
 
 	/* this should really be moved out of the proc - we'll worry about it later */
-	snprintf(raceI->headpath, PATH_MAX, "%s/%s/headdata", storage, path);
+	safe_snprintf(raceI->headpath, PATH_MAX, "%s/%s/headdata", storage, path);
 
 	if ((fd = open(raceI->headpath, O_CREAT | O_RDWR, 0666)) == -1) {
 		d_log("create_lock: open(%s): %s\n", raceI->headpath, strerror(errno));
@@ -1229,7 +1227,7 @@ remove_lock(struct VARS *raceI)
 	}
 	close(fd);
 
-	snprintf(lockfile, sizeof lockfile, "%s.lock", raceI->headpath);
+	safe_snprintf(lockfile, sizeof(lockfile), "%s.lock", raceI->headpath);
 	unlink(lockfile);
 	
 	d_log("remove_lock: queue %d/%d\n", hd.data_qcurrent, hd.data_queue);

--- a/zipscript/src/race-file.c
+++ b/zipscript/src/race-file.c
@@ -1094,7 +1094,7 @@ create_lock(struct VARS *raceI, const char *path, unsigned int progtype, unsigne
 		raceI->misc.release_type = hd.data_type;
 		raceI->misc.data_completed = hd.data_completed;
 
-		// unlink(lockfile); NOT PRESENT but seems to be missing
+		unlink(lockfile);
 		close(fd);
 		return hd.data_in_use;
 	} else { 		/* looks like the lock is inactive */

--- a/zipscript/src/race-file.c
+++ b/zipscript/src/race-file.c
@@ -1607,6 +1607,7 @@ read_headdata(const char *headpath)
 	}
 	if ((read(fd, &hd, sizeof(HEADDATA))) != sizeof(HEADDATA)) {
 		d_log("read_headdata: failed to read %s : %s - returning '0' as data_type\n", headpath, strerror(errno));
+		close(fd);
 		return 0;
 	}
 	close(fd);

--- a/zipscript/src/race-file.c
+++ b/zipscript/src/race-file.c
@@ -990,7 +990,7 @@ create_lock_link(struct VARS *raceI) {
 	char lockfile[PATH_MAX + 1];
 	struct stat lock_stat;
 
-	safe_snprintf(lockfile, sizeof(lockfile), raceI->headpath, "%s.lock");
+	safe_snprintf(lockfile, sizeof(lockfile), "%s.lock", raceI->headpath);
 	if (!stat(lockfile, &lock_stat) && (time(NULL) - lock_stat.st_ctime >= max_seconds_wait_for_lock * 5)) {
 		unlink(lockfile);
 	}
@@ -1015,7 +1015,7 @@ create_lock_link(struct VARS *raceI) {
 void
 remove_lock_link(struct VARS *raceI) {
 	char lockfile[PATH_MAX + 1];
-	safe_snprintf(lockfile, sizeof(lockfile), raceI->headpath, "%s.lock");	
+	safe_snprintf(lockfile, sizeof(lockfile), "%s.lock", raceI->headpath);
 	unlink(lockfile);
 }
 

--- a/zipscript/src/race-file.c
+++ b/zipscript/src/race-file.c
@@ -1068,8 +1068,9 @@ create_lock(struct VARS *raceI, const char *path, unsigned int progtype, unsigne
 		hd.data_pid = (unsigned int)getpid();
 
 		lseek(fd, 0L, SEEK_SET);
-		if (write(fd, &hd, sizeof(HEADDATA)) != sizeof(HEADDATA))
+		if (write(fd, &hd, sizeof(HEADDATA)) != sizeof(HEADDATA)) {
 			d_log("create_lock: write failed: %s\n", strerror(errno));
+		}
 		d_log("create_lock: lock set. (lockfile exceeded max life time) pid: %d\n", hd.data_pid);
 
 		close(fd);
@@ -1087,8 +1088,9 @@ create_lock(struct VARS *raceI, const char *path, unsigned int progtype, unsigne
 			hd.data_queue++;			/* we increment the number in the queue */
 
 			lseek(fd, 0L, SEEK_SET);
-			if (write(fd, &hd, sizeof(HEADDATA)) != sizeof(HEADDATA))
+			if (write(fd, &hd, sizeof(HEADDATA)) != sizeof(HEADDATA)) {
 				d_log("create_lock: write failed: %s\n", strerror(errno));
+			}
 			d_log("create_lock: lock active - putting you in queue. (%d/%d)\n", hd.data_qcurrent, hd.data_queue);
 		}
 		raceI->misc.release_type = hd.data_type;
@@ -1109,8 +1111,9 @@ create_lock(struct VARS *raceI, const char *path, unsigned int progtype, unsigne
 			raceI->misc.release_type = hd.data_type;
 			raceI->misc.data_completed = hd.data_completed;
 			lseek(fd, 0L, SEEK_SET);
-			if (write(fd, &hd, sizeof(HEADDATA)) != sizeof(HEADDATA))
+			if (write(fd, &hd, sizeof(HEADDATA)) != sizeof(HEADDATA)) {
 				d_log("create_lock: write failed: %s\n", strerror(errno));
+			}
 			d_log("create_lock: putting you in queue. (%d/%d)\n", hd.data_qcurrent, hd.data_queue);
 
 			unlink(lockfile);
@@ -1143,8 +1146,9 @@ create_lock(struct VARS *raceI, const char *path, unsigned int progtype, unsigne
 	hd.data_pid = (unsigned int)getpid();
 
 	lseek(fd, 0L, SEEK_SET);
-	if (write(fd, &hd, sizeof(HEADDATA)) != sizeof(HEADDATA))
+	if (write(fd, &hd, sizeof(HEADDATA)) != sizeof(HEADDATA)) {
 		d_log("create_lock: write failed: %s\n", strerror(errno));
+	}
 	raceI->data_in_use = progtype;
 
 	d_log("create_lock: lock set. pid: %d\n", hd.data_pid);
@@ -1158,42 +1162,55 @@ create_lock(struct VARS *raceI, const char *path, unsigned int progtype, unsigne
 void
 remove_lock(struct VARS *raceI)
 {
-	if (!raceI->data_in_use)
+	if (!raceI->data_in_use) {
 		d_log("remove_lock: lock not removed - no lock was set\n");
-	else {
-		int		fd;
-		HEADDATA	hd;
-		char		lockfile[PATH_MAX + 1];
-
-		if ((fd = open(raceI->headpath, O_RDWR, 0666)) == -1) {
-			d_log("remove_lock: open(%s): %s\n", raceI->headpath, strerror(errno));
-			exit(EXIT_FAILURE);
-		}
-
-		if (read(fd, &hd, sizeof(HEADDATA)) == -1) {
-			d_log("remove_lock: read() failed: %s\n", strerror(errno));
-			hd.data_queue = 0;
-			hd.data_qcurrent = 0;
-		}
-
-		hd.data_in_use = 0;
-		hd.data_pid = 0;
-		hd.data_completed = raceI->misc.data_completed;
-		hd.data_incrementor = 0;
-		if (hd.data_queue)			/* if queue, increase the number in current so the next */
-			++hd.data_qcurrent;		/* process can start. */
-		if (hd.data_queue < hd.data_qcurrent) {	/* If the next in line is bigger than the queue itself, */
-			hd.data_queue = 0;		/* it should be fair to assume there is noone else in queue */
-			hd.data_qcurrent = 0;		/* and reset the queue. Normally, this should not happen. */
-		}
-		lseek(fd, 0L, SEEK_SET);
-		if (write(fd, &hd, sizeof(HEADDATA)) != sizeof(HEADDATA))
-			d_log("remove_lock: write failed: %s\n", strerror(errno));
-		close(fd);
-		snprintf(lockfile, sizeof lockfile, "%s.lock", raceI->headpath);
-		unlink(lockfile);
-		d_log("remove_lock: queue %d/%d\n", hd.data_qcurrent, hd.data_queue);
+		return;
 	}
+
+	int			fd;
+	HEADDATA	hd;
+	char		lockfile[PATH_MAX + 1];
+
+	if ((fd = open(raceI->headpath, O_RDWR, 0666)) == -1) {
+		d_log("remove_lock: open(%s): %s\n", raceI->headpath, strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+
+	if (read(fd, &hd, sizeof(HEADDATA)) == -1) {
+		d_log("remove_lock: read() failed: %s\n", strerror(errno));
+		hd.data_queue = 0;
+		hd.data_qcurrent = 0;
+	}
+
+	hd.data_in_use = 0;
+	hd.data_pid = 0;
+	hd.data_completed = raceI->misc.data_completed;
+	hd.data_incrementor = 0;
+
+	/* if queue, increase the number in current so the next */
+	/* process can start. */
+	if (hd.data_queue) {
+		++hd.data_qcurrent;
+	}
+
+	/* If the next in line is bigger than the queue itself, */
+	/* it should be fair to assume there is no one else in queue */
+	/* and reset the queue. Normally, this should not happen. */
+	if (hd.data_queue < hd.data_qcurrent) {	
+		hd.data_queue = 0;		
+		hd.data_qcurrent = 0;		
+	}
+
+	lseek(fd, 0L, SEEK_SET);
+	if (write(fd, &hd, sizeof(HEADDATA)) != sizeof(HEADDATA)) {
+		d_log("remove_lock: write failed: %s\n", strerror(errno));
+	}
+	close(fd);
+
+	snprintf(lockfile, sizeof lockfile, "%s.lock", raceI->headpath);
+	unlink(lockfile);
+	
+	d_log("remove_lock: queue %d/%d\n", hd.data_qcurrent, hd.data_queue);
 }
 
 /* update a lock. This should be used after each file checked.
@@ -1201,6 +1218,8 @@ remove_lock(struct VARS *raceI)
  * Please note:
  *   if counter == 0 a suggested lock-removal will be written. if >0 it's used as normal.
  *   if datatype != 0, this datatype will be written.
+ *
+ *  return: 0 - lock remove suggested
  */
 
 int
@@ -1208,7 +1227,7 @@ update_lock(struct VARS *raceI, unsigned int counter, unsigned int datatype)
 {
 	int		fd, retval;
 	HEADDATA	hd;
-	struct stat	sb;
+	struct stat	head_stat;
 
 	if (!raceI->headpath[0]) {
 		d_log("update_lock: variable 'headpath' empty - assuming no lock is set\n");
@@ -1225,6 +1244,7 @@ update_lock(struct VARS *raceI, unsigned int counter, unsigned int datatype)
 		remove_lock(raceI);
 		exit(EXIT_FAILURE);
 	}
+
 	if (read(fd, &hd, sizeof(HEADDATA)) == -1) {
 		d_log("update_lock: read() failed: %s\n", strerror(errno));
 	}
@@ -1234,12 +1254,14 @@ update_lock(struct VARS *raceI, unsigned int counter, unsigned int datatype)
 		close(fd);
 		return 1;
 	}
+
 	if ((hd.data_in_use != raceI->data_in_use) && counter) {
 		d_log("update_lock: Lock not active or progtype mismatch - no choice but to exit.\n");
 		close(fd);
 		remove_lock(raceI);
 		exit(EXIT_FAILURE);
 	}
+	
 	if (!hd.data_incrementor) {
 		d_log("update_lock: Lock suggested removed by a different process (%d/%d).\n", hd.data_incrementor, raceI->data_incrementor);
 		retval = 0;
@@ -1251,25 +1273,30 @@ update_lock(struct VARS *raceI, unsigned int counter, unsigned int datatype)
 
 		retval = hd.data_incrementor;
 	}
+
 	raceI->misc.release_type = hd.data_type;
 	raceI->misc.data_completed = hd.data_completed;
 	if (hd.data_pid != (unsigned int)getpid() && hd.data_incrementor) {
 		d_log("update_lock: Oops! Race condition - another process has the lock. pid: %d != %d\n", hd.data_pid, (unsigned int)getpid());
 		hd.data_queue = raceI->data_queue - 1;
 		lseek(fd, 0L, SEEK_SET);
-		if (write(fd, &hd, sizeof(HEADDATA)) != sizeof(HEADDATA))
+		if (write(fd, &hd, sizeof(HEADDATA)) != sizeof(HEADDATA)) {
 			d_log("create_lock: write failed: %s\n", strerror(errno));
+		}
 		close(fd);
 		return -1;
 	}
-	if (datatype && counter)
-		hd.data_type = datatype;
 
-	fstat(fd, &sb);
-	if ((retval && !lock_optimize) || datatype || !retval || !hd.data_incrementor || (time(NULL) - sb.st_ctime >= lock_optimize && hd.data_incrementor > 1)) {
+	if (datatype && counter) {
+		hd.data_type = datatype;
+	}
+
+	fstat(fd, &head_stat);
+	if ((retval && !lock_optimize) || datatype || !retval || !hd.data_incrementor || (time(NULL) - head_stat.st_ctime >= lock_optimize && hd.data_incrementor > 1)) {
 		lseek(fd, 0L, SEEK_SET);
-		if (write(fd, &hd, sizeof(HEADDATA)) != sizeof(HEADDATA))
+		if (write(fd, &hd, sizeof(HEADDATA)) != sizeof(HEADDATA)) {
 			d_log("create_lock: write failed: %s\n", strerror(errno));
+		}
 		d_log("update_lock: updating lock (%d)\n", raceI->data_incrementor);
 	}
 	close(fd);

--- a/zipscript/src/zipscript-c.c
+++ b/zipscript/src/zipscript-c.c
@@ -471,7 +471,7 @@ main(int argc, char **argv)
 				}
 			} else {
 				for ( n = 0; n <= max_seconds_wait_for_lock * 10; n++) {
-					d_log("zipscript-c: sleeping for .1 second before trying to get a lock.\n");
+					d_log("zipscript-c: sleeping for .1 second before trying to get a lock before scanning %s.\n", argv[1]);
 					usleep(100000);
 					if (!(m = create_lock(&g.v, g.l.path, PROGTYPE_ZIPSCRIPT, 0, g.v.data_queue)))
 						break;

--- a/zipscript/src/zsfunctions.c
+++ b/zipscript/src/zsfunctions.c
@@ -1,5 +1,6 @@
 #include <errno.h>
 #include <fnmatch.h>
+#include <stdlib.h>
 #include "zsfunctions.h"
 
 #include "ng-version.h"
@@ -1962,4 +1963,20 @@ _err_file_banned(const char *fn, struct VARS *v) {
 		exit(EXIT_FAILURE);
 	}
 	return 0;
+}
+
+
+void
+safe_snprintf(char *buffer, size_t size, const char *format, ...) {
+    va_list args;
+    va_start(args, format);
+    int result = vsnprintf(buffer, size, format, args);
+	char *first_arg = va_arg(args, char*);
+    va_end(args);
+    
+    // Check for truncation
+    if (result < 0 || (size_t)result >= size) {
+		d_log("resulting file path too long : %s (format %s) (max length %d)", first_arg, format, size);
+		exit(EXIT_FAILURE);
+    }
 }

--- a/zipscript/src/zsfunctions.c
+++ b/zipscript/src/zsfunctions.c
@@ -1968,12 +1968,15 @@ _err_file_banned(const char *fn, struct VARS *v) {
 
 void
 safe_snprintf(char *buffer, size_t size, const char *format, ...) {
-    va_list args;
+    va_list args, args_copy;
     va_start(args, format);
+    va_copy(args_copy, args);
     int result = vsnprintf(buffer, size, format, args);
-	char *first_arg = va_arg(args, char*);
+    char *first_arg = va_arg(args_copy, char*);
+
     va_end(args);
-    
+	va_end(args_copy);
+
     // Check for truncation
     if (result < 0 || (size_t)result >= size) {
 		d_log("resulting file path too long : %s (format %s) (max length %d)", first_arg, format, size);


### PR DESCRIPTION
This PR introduces a first step to address the issue discussed in https://github.com/pzs-ng/pzs-ng/issues/30 .
Various fixes and no new functionality are introduced in this PR.
Locking is still broken due to the current design: most likely lock-files for the head data will still appear, but hopefully less often. This will be hopefully addressed in an upcoming PR.


- In particular, in race-file.c the create, remove and update lock methods have been revised for increased readability. 
There were also some gaps that could cause potential issues.
- Some safety snprintf wrapper is introduced to reduce the number of compilation warnings.
- Code has been tested with various file-formats.
- Version has been bumped to 1.2.1 since it contains since it contains more impactful changes.

Commits are not squashed so a review is easier to perform, please squash the commits when merging!