### PR TITLE
Fix bug introduced in #36

### DIFF
--- a/zipscript/src/postdel.c
+++ b/zipscript/src/postdel.c
@@ -97,7 +97,6 @@ main(int argc, char **argv)
 	// Change to the prefixed directory
 	if (chdir(prefixed_dirname) != 0) {
 		d_log("postdel: Failed to change directory to '%s': %s\n", prefixed_dirname, strerror(errno));
-		return 0;
 	}
 
 	d_log("postdel: Got a 'DELE %s' in '%s'\n", fname, prefixed_dirname);


### PR DESCRIPTION
The old behavior before #36 was merged can be recreated by removing this early return. This should ensure that both the bug fixed in previous PR and the old behavior for other cases are working as expected.