### PR TITLE
Add configurable millisecond precision to race timing

### DIFF
--- a/README.ZSCONFIG
+++ b/README.ZSCONFIG
@@ -507,6 +507,15 @@ debug_mode <TRUE|FALSE>
 	Related option(s): debug_altlog debug_announce
 	Default: FALSE
 
+time_precision <INTEGER>
+	Number of decimal places to show for seconds in duration output.
+	Valid values: 0-3
+	0 = no decimal places (82s, 1m22s)
+	1 = one decimal place (82.3s, 1m22.3s)
+	2 = two decimal places (82.39s, 1m22.39s)
+	3 = three decimal places for milliseconds (82.396s, 1m22.396s)
+	Default: 3
+
 del_banned_release <TRUE|FALSE>
 	If you want to make absolutely sure the banned release does not take up
 	more bandwith or space than necessary, you can choose to completely

--- a/sitebot/themes/custom.zst
+++ b/sitebot/themes/custom.zst
@@ -1,0 +1,174 @@
+# Custom theme with GB formatting and thousand separators
+# Based on default.zst
+
+##############################################################################
+#                                                                            #
+#  custom.zst  -  pzs-ng custom theme with GB formatting                    #
+#                                                                            #
+#  Created for: Custom formatting requirements                               #
+#  Features: GB instead of MB, thousand separators (comma)                   #
+#                                                                            #
+##############################################################################
+
+# Use %c#{text} for colors (see below), %u{text} for underlining, %b{text} for bold,
+# %T{text} for Titlecasing, %U{text} for UPPERCASING, %L{text} for lowercasing,
+# %l#{text} for leftalignmentpadding, %r#{text} for rightalignmentpadding and
+# %m#{text} for middlealignmentpadding
+
+# Default colors
+COLOR1      = "04"
+COLOR2      = "07"
+COLOR3      = "11"
+
+PREFIX      = "%b{%sitename} :: "
+SPLITTER    = ", "
+KB          = "%b{%value}KB/s"
+MB          = "%b{%value}MB/s"
+KBIT        = "%b{%value}Kbit/s"
+MBIT        = "%b{%value}Mbit/s"
+fakesection.INVITE = "iNViTE"
+
+## Default announce
+announce.DEFAULT                    = "%msg"
+
+## SFV announces
+announce.SFV_AUDIO                  = "[%b{sfv   }][%section] %b{%reldir} (%b{%t_filecount}F expected) was uploaded by %b{%u_name} of %b{%g_name}."
+announce.SFV_OTHER                  = "[%b{sfv   }][%section] %b{%relname} (%b{%t_filecount}F expected) was uploaded by %b{%u_name} of %b{%g_name}."
+announce.SFV_RAR                    = "[%b{sfv   }][%section] %b{%relname} (%b{%t_filecount}F expected) was uploaded by %b{%u_name} of %b{%g_name}."
+announce.SFV_VIDEO                  = "[%b{sfv   }][%section] %b{%relname} (%b{%t_filecount}F expected) was uploaded by %b{%u_name} of %b{%g_name}."
+announce.SFV_ZIP                    = "[%b{sfv   }][%section] %b{%reldir} (%b{%t_filecount}F expected) was uploaded by %b{%u_name} of %b{%g_name}."
+
+## Bad file announces
+announce.BAD_FILE_0SIZE             = "[%b{%c1{!dupe }}][%section] %b{%releasename}: %b{%u_name} of %g_name uploaded a 0byte file (%b{%filename})."
+announce.BAD_FILE_CRC               = "[%b{%c1{!dupe }}][%section] %b{%releasename}: %b{%u_name} of %g_name uploaded a bad file (%b{%filename})."
+announce.BAD_FILE_DISALLOWED        = "[%b{%c1{!dupe }}][%section] %b{%releasename}: %b{%u_name} of %g_name uploaded a disallowed file (%b{%filename})."
+announce.BAD_FILE_DUPENFO           = "[%b{%c1{!dupe }}][%section] %b{%releasename}: %b{%u_name} of %g_name uploaded a duped nfo (%b{%filename})."
+announce.BAD_FILE_DUPERELEASE       = "[%b{%c1{!dupe }}][%section] %b{%releasename}: This release has been nuked/deleted before."
+announce.BAD_FILE_NOSFV             = "[%b{%c1{!dupe }}][%section] %b{%releasename}: %b{%u_name} of %g_name uploaded without sfv (%b{%filename})."
+announce.BAD_FILE_SFV               = "[%b{%c1{!dupe }}][%section] %b{%releasename}: %b{%u_name} of %g_name uploaded a bad sfv (%b{%filename})."
+announce.BAD_FILE_WRONGDIR          = "[%b{%c1{!dupe }}][%section] %b{%releasename}: %b{%u_name} of %g_name tried to upload %filename in the wrong section."
+announce.BAD_FILE_ZIP               = "[%b{%c1{!dupe }}][%section] %b{%releasename}: %b{%u_name} of %g_name uploaded a bad zip (%b{%filename})."
+announce.BAD_FILE_ZIPNFO            = "[%b{%c1{!dupe }}][%section] %b{%releasename}: %b{%u_name} of %g_name uploaded a nfo in a zip dir (%b{%filename})."
+
+## Audio bad file announces
+announce.BAD_FILE_BITRATE           = "[%b{%c1{!dupe }}][%section] %b{%releasename}: %b{%u_name} of %g_name uploaded an mp3 with a disallowed bitrate (%b{%filename})."
+announce.BAD_FILE_GENRE             = "[%b{%c1{!dupe }}][%section] %b{%releasename}: %b{%u_name} of %g_name uploaded an mp3 from a disallowed genre (%b{%filename})."
+announce.BAD_FILE_YEAR              = "[%b{%c1{!dupe }}][%section] %b{%releasename}: %b{%u_name} of %g_name uploaded an mp3 from a disallowed year (%b{%filename})."
+
+## Double sfv/nfo/sample announces
+announce.DOUBLESFV                  = "[%b{%c1{!dupe }}][%section] %b{%releasename}: %b{%u_name} of %g_name tried to upload a second sfv."
+announce.RESUMESFV                  = "[%b{%c1{!dupe }}][%section] %b{%releasename}: %b{%u_name} of %g_name tried to resume/overwrite the sfv."
+
+## Update/first file announces
+announce.UPDATE_CBR                 = "[%b{mp3   }][%section] %b{%reldir} (%b{%genre}/%b{%year}/%b{%sampling}Hz/%b{%mode}/%b{%bitrate}kbit) was uploaded by %b{%u_name} of %b{%g_name} at %b{%u_speed}."
+announce.UPDATE_OTHER               = "[%b{new   }][%section] %b{%relname} (%b{%t_files}F expected) was uploaded by %b{%u_name} of %b{%g_name} at %b{%u_speed}."
+announce.UPDATE_RAR                 = "[%b{new   }][%section] %b{%relname} (%b{%t_files}F expected) was uploaded by %b{%u_name} of %b{%g_name} at %b{%u_speed}."
+announce.UPDATE_VBR                 = "[%b{mp3   }][%section] %b{%reldir} (%b{%genre}/%b{%year}/%b{%sampling}Hz/%b{%mode}/%b{%bitrate}kbit/%b{%audio %a_stream}) was uploaded by %b{%u_name} of %b{%g_name} at %b{%u_speed}."
+announce.UPDATE_VIDEO               = "[%b{new   }][%section] %b{%relname} (%b{%t_files}F expected) was uploaded by %b{%u_name} of %b{%g_name} at %b{%u_speed}."
+announce.UPDATE_ZIP                 = "[%b{new   }][%section] %b{%reldir} (%b{%t_files}F expected) was uploaded by %b{%u_name} of %b{%g_name} at %b{%u_speed}."
+
+## Race announces
+announce.RACE_AUDIO                 = "[%b{race  }][%section] %b{%reldir} is being raced by%loop1 at %b{%u_speed}. %b{%t_percent}%% done (%b{%t_mbytes}MB/%b{%t_files}F done)."
+announce.RACE_OTHER                 = "[%b{race  }][%section] %b{%relname} is being raced by%loop1 at %b{%u_speed}. %b{%t_percent}%% done (%b{%t_mbytes}MB/%b{%t_files}F done)."
+announce.RACE_RAR                   = "[%b{race  }][%section] %b{%relname} is being raced by%loop1 at %b{%u_speed}. %b{%t_percent}%% done (%b{%t_mbytes}MB/%b{%t_files}F done)."
+announce.RACE_VIDEO                 = "[%b{race  }][%section] %b{%relname} is being raced by%loop1 at %b{%u_speed}. %b{%t_percent}%% done (%b{%t_mbytes}MB/%b{%t_files}F done)."
+announce.RACE_ZIP                   = "[%b{race  }][%section] %b{%reldir} is being raced by%loop1 at %b{%u_speed}. %b{%t_percent}%% done (%b{%t_mbytes}MB/%b{%t_files}F done)."
+
+## Newleader announces
+announce.NEWLEADER_AUDIO            = "[%b{racing}][%section] %b{%u_name}@%b{%g_name} takes the lead in %b{%reldir}. %b{%t_percent}%% done (%b{%t_mbytes}MB/%b{%t_files}F done) at %b{%t_avgspeed}."
+announce.NEWLEADER_OTHER            = "[%b{racing}][%section] %b{%u_name}@%b{%g_name} takes the lead in %b{%relname}. %b{%t_percent}%% done (%b{%t_mbytes}MB/%b{%t_files}F done) at %b{%t_avgspeed}."
+announce.NEWLEADER_RAR              = "[%b{racing}][%section] %b{%u_name}@%b{%g_name} takes the lead in %b{%relname}. %b{%t_percent}%% done (%b{%t_mbytes}MB/%b{%t_files}F done) at %b{%t_avgspeed}."
+announce.NEWLEADER_VIDEO            = "[%b{racing}][%section] %b{%u_name}@%b{%g_name} takes the lead in %b{%relname}. %b{%t_percent}%% done (%b{%t_mbytes}MB/%b{%t_files}F done) at %b{%t_avgspeed}."
+announce.NEWLEADER_ZIP              = "[%b{racing}][%section] %b{%u_name}@%b{%g_name} takes the lead in %b{%reldir}. %b{%t_percent}%% done (%b{%t_mbytes}MB/%b{%t_files}F done) at %b{%t_avgspeed}."
+
+## Halfway announces
+announce.HALFWAY_NORACE_AUDIO       = "[%b{midway}][%section] %b{%reldir} is now %b{%t_percent}%% complete (%b{%t_mbytes}MB/%b{%t_files}F done at %t_avgspeed) Leader: %b{%u_leader_name}/%u_leader_gname."
+announce.HALFWAY_NORACE_OTHER       = "[%b{midway}][%section] %b{%relname} is now %b{%t_percent}%% complete (%b{%t_mbytes}MB/%b{%t_files}F done at %t_avgspeed) Leader: %b{%u_leader_name}/%u_leader_gname."
+announce.HALFWAY_NORACE_RAR         = "[%b{midway}][%section] %b{%relname} is now %b{%t_percent}%% complete (%b{%t_mbytes}MB/%b{%t_files}F done at %t_avgspeed) Leader: %b{%u_leader_name}/%u_leader_gname."
+announce.HALFWAY_NORACE_VIDEO       = "[%b{midway}][%section] %b{%relname} is now %b{%t_percent}%% complete (%b{%t_mbytes}MB/%b{%t_files}F done at %t_avgspeed) Leader: %b{%u_leader_name}/%u_leader_gname."
+announce.HALFWAY_NORACE_ZIP         = "[%b{midway}][%section] %b{%reldir} is now %b{%t_percent}%% complete (%b{%t_mbytes}MB/%b{%t_files}F done at %t_avgspeed) Leader: %b{%u_leader_name}/%u_leader_gname."
+announce.HALFWAY_RACE_AUDIO         = "[%b{midway}][%section] %b{%reldir} is now %b{%t_percent}%% complete (%b{%t_mbytes}MB/%b{%t_files}F done at %t_avgspeed) Leader: %b{%u_leader_name}/%u_leader_gname."
+announce.HALFWAY_RACE_OTHER         = "[%b{midway}][%section] %b{%relname} is now %b{%t_percent}%% complete (%b{%t_mbytes}MB/%b{%t_files}F done at %t_avgspeed) Leader: %b{%u_leader_name}/%u_leader_gname."
+announce.HALFWAY_RACE_RAR           = "[%b{midway}][%section] %b{%relname} is now %b{%t_percent}%% complete (%b{%t_mbytes}MB/%b{%t_files}F done at %t_avgspeed) Leader: %b{%u_leader_name}/%u_leader_gname."
+announce.HALFWAY_RACE_VIDEO         = "[%b{midway}][%section] %b{%relname} is now %b{%t_percent}%% complete (%b{%t_mbytes}MB/%b{%t_files}F done at %t_avgspeed) Leader: %b{%u_leader_name}/%u_leader_gname."
+announce.HALFWAY_RACE_ZIP           = "[%b{midway}][%section] %b{%reldir} is now %b{%t_percent}%% complete (%b{%t_mbytes}MB/%b{%t_files}F done at %t_avgspeed) Leader: %b{%u_leader_name}/%u_leader_gname."
+
+## Complete announces (single racer)
+announce.COMPLETE_AUDIO_CBR         = "[%b{done  }][%section] %b{%reldir} with %b{%t_files} files (%[format "%.3f" [expr {%t_mbytes / 1024.0}]]GB) was completed in %b{%t_duration} (avg. %r_avgspeed) by %b{%u_name} of %b{%g_name}."
+announce.COMPLETE_AUDIO_VBR         = "[%b{done  }][%section] %b{%reldir} with %b{%t_files} files (%[format "%.3f" [expr {%t_mbytes / 1024.0}]]GB) was completed in %b{%t_duration} (avg. %r_avgspeed) by %b{%u_name} of %b{%g_name}."
+announce.COMPLETE_OTHER             = "[%b{done  }][%section] %b{%relname} with %b{%t_files} files (%[format "%.3f" [expr {%t_mbytes / 1024.0}]]GB) was completed in %b{%t_duration} (avg. %r_avgspeed) by %b{%u_name} of %b{%g_name}."
+announce.COMPLETE_RAR               = "[%b{done  }][%section] %b{%relname} with %b{%t_files} files (%[format "%.3f" [expr {%t_mbytes / 1024.0}]]GB) was completed in %b{%t_duration} (avg. %r_avgspeed) by %b{%u_name} of %b{%g_name}."
+announce.COMPLETE_VIDEO             = "[%b{done  }][%section] %b{%relname} with %b{%t_files} files (%[format "%.3f" [expr {%t_mbytes / 1024.0}]]GB) was completed in %b{%t_duration} (avg. %r_avgspeed) by %b{%u_name} of %b{%g_name}."
+announce.COMPLETE_ZIP               = "[%b{done  }][%section] %b{%reldir} with %b{%t_files} files (%[format "%.3f" [expr {%t_mbytes / 1024.0}]]GB) was completed in %b{%t_duration} (avg. %r_avgspeed) by %b{%u_name} of %b{%g_name}."
+
+## Complete announces (multi racers) - WITH FORMATTING
+announce.COMPLETE_STAT_RACE_AUDIO_CBR   = "[%b{%c2{COMPLETE}}][%section] %b{%reldir} · %b{%u_count} racers (%b{%t_mbytes}MB %b{%t_files}F %t_avgspeed) in %b{%t_duration}"
+announce.COMPLETE_STAT_RACE_AUDIO_VBR   = "[%b{%c2{COMPLETE}}][%section] %b{%reldir} · %b{%u_count} racers (%b{%t_mbytes}MB %b{%t_files}F %t_avgspeed) in %b{%t_duration}"
+announce.COMPLETE_STAT_RACE_OTHER       = "[%b{%c2{COMPLETE}}][%section] %b{%relname} · %b{%u_count} racers (%b{%t_mbytes}MB %b{%t_files}F %t_avgspeed) in %b{%t_duration}"
+announce.COMPLETE_STAT_RACE_RAR         = "[%b{%c2{COMPLETE}}][%section] %b{%relname} · %b{%u_count} racers (%b{%t_mbytes}MB %b{%t_files}F %t_avgspeed) in %b{%t_duration}"
+announce.COMPLETE_STAT_RACE_VIDEO       = "[%b{%c2{COMPLETE}}][%section] %b{%relname} · %b{%u_count} racers (%b{%t_mbytes}MB %b{%t_files}F %t_avgspeed) in %b{%t_duration}"
+announce.COMPLETE_STAT_RACE_ZIP         = "[%b{%c2{COMPLETE}}][%section] %b{%reldir} · %b{%u_count} racers (%b{%t_mbytes}MB %b{%t_files}F %t_avgspeed) in %b{%t_duration}"
+
+## Loop variables for stats
+announce.COMPLETE_STAT_RACE_AUDIO_CBR_LOOP1  = "%b{%r_name}/%r_gname%splitter"
+announce.COMPLETE_STAT_RACE_AUDIO_CBR_LOOP2  = " %b{%g_racer_name}: %b{%g_racer_mbytes}MB (%b{%g_racer_percent}%%) @ %b{%g_racer_avgspeed}%splitter"
+announce.COMPLETE_STAT_RACE_AUDIO_CBR_LOOP3  = " %b{%u_racer_name}: %b{%u_racer_mbytes}MB (%b{%u_racer_percent}%%) @ %b{%u_racer_avgspeed}%splitter"
+announce.COMPLETE_STAT_RACE_AUDIO_VBR_LOOP1  = "%b{%r_name}/%r_gname%splitter"
+announce.COMPLETE_STAT_RACE_AUDIO_VBR_LOOP2  = " %b{%g_racer_name}: %b{%g_racer_mbytes}MB (%b{%g_racer_percent}%%) @ %b{%g_racer_avgspeed}%splitter"
+announce.COMPLETE_STAT_RACE_AUDIO_VBR_LOOP3  = " %b{%u_racer_name}: %b{%u_racer_mbytes}MB (%b{%u_racer_percent}%%) @ %b{%u_racer_avgspeed}%splitter"
+announce.COMPLETE_STAT_RACE_OTHER_LOOP1      = "%b{%r_name}/%r_gname%splitter"
+announce.COMPLETE_STAT_RACE_OTHER_LOOP2      = " %b{%g_racer_name}: %b{%g_racer_mbytes}MB (%b{%g_racer_percent}%%) @ %b{%g_racer_avgspeed}%splitter"
+announce.COMPLETE_STAT_RACE_OTHER_LOOP3      = " %b{%u_racer_name}: %b{%u_racer_mbytes}MB (%b{%u_racer_percent}%%) @ %b{%u_racer_avgspeed}%splitter"
+announce.COMPLETE_STAT_RACE_RAR_LOOP1        = "%b{%r_name}/%r_gname%splitter"
+announce.COMPLETE_STAT_RACE_RAR_LOOP2        = " %b{%g_racer_name}: %b{%g_racer_mbytes}MB (%b{%g_racer_percent}%%) @ %b{%g_racer_avgspeed}%splitter"
+announce.COMPLETE_STAT_RACE_RAR_LOOP3        = " %b{%u_racer_name}: %b{%u_racer_mbytes}MB (%b{%u_racer_percent}%%) @ %b{%u_racer_avgspeed}%splitter"
+announce.COMPLETE_STAT_RACE_VIDEO_LOOP1      = "%b{%r_name}/%r_gname%splitter"
+announce.COMPLETE_STAT_RACE_VIDEO_LOOP2      = " %b{%g_racer_name}: %b{%g_racer_mbytes}MB (%b{%g_racer_percent}%%) @ %b{%g_racer_avgspeed}%splitter"
+announce.COMPLETE_STAT_RACE_VIDEO_LOOP3      = " %b{%u_racer_name}: %b{%u_racer_mbytes}MB (%b{%u_racer_percent}%%) @ %b{%u_racer_avgspeed}%splitter"
+announce.COMPLETE_STAT_RACE_ZIP_LOOP1        = "%b{%r_name}/%r_gname%splitter"
+announce.COMPLETE_STAT_RACE_ZIP_LOOP2        = " %b{%g_racer_name}: %b{%g_racer_mbytes}MB (%b{%g_racer_percent}%%) @ %b{%g_racer_avgspeed}%splitter"
+announce.COMPLETE_STAT_RACE_ZIP_LOOP3        = " %b{%u_racer_name}: %b{%u_racer_mbytes}MB (%b{%u_racer_percent}%%) @ %b{%u_racer_avgspeed}%splitter"
+
+## Postdel announce
+announce.INCOMPLETE             = "[%b{d0h!  }][%section] %b{%releasename} is now incomplete thanks to %b{%u_name} of %b{%g_name}."
+
+## Third party scripts
+announce.PRE                    = "[%b{%c1{pre}   }][%section] %b{%relname} by %b{%pregroup} in %b{%files} files (%b{%mbytes}MB)."
+announce.TURGEN                 = "%msg"
+announce.WHOIS                  = "[%b{whois }] %msg"
+
+## Miscellaneous announcements
+announce.BADMSGINVITE           = "[%b{%c1{badinv}}] %b{%u_ircnick} (%u_host) tried to invite himself with invalid login!"
+announce.INVITE                 = "[%b{invite}] %b{%u_name} of %g_name invited himself as %b{%u_ircnick}."
+announce.MSGINVITE              = "[%b{invite}] %b{%u_name} of %g_name has been invited by %b{%i_name}."
+announce.REQUESTFILLED          = "[%b{reqfil}] %b{%u_name} of %g_name has filled a request: %b{%releasename}."
+announce.REQUEST                = "[%b{req   }] %b{%u_name} of %g_name requests: %b{%releasename}."
+
+## LOGIN/LOGOUT/TIMEOUT/BADHOSTMASK/BADPASSWORD/ADDUSER
+announce.ADDIP                  = "[%b{addip }] %b{%u_siteop} added IP %b{%u_ip} to %b{%u_name}."
+announce.ADDUSER                = "[%b{siteop}] %b{%u_siteop} added user %b{%u_name}."
+announce.BADHOSTMASK            = "[%b{login }] Failed login by %b{%u_name} (%b{%u_ip}/%b{%u_hostmask})."
+announce.BADPASSWORD            = "[%b{login }] Failed login by %b{%u_name} (%b{%u_ip}/%b{%u_hostmask})."
+announce.BADUSERNAME            = "[%b{login }] Failed login by unknown user from %b{%u_ip}/%b{%u_hostmask}."
+announce.BADEMAILPASS           = "[%b{email }] %b{%u_name} (%b{%u_ip}/%b{%u_hostmask}) tried to invite himself with invalid password."
+announce.BANNEDHOST             = "[%b{banned}] Banned host tried to login: %b{%u_ip}/%b{%u_hostmask}."
+announce.CHGRPADD               = "[%b{siteop}] %b{%u_siteop} added %b{%u_name} to group %b{%g_name}."
+announce.CHGRPDEL               = "[%b{siteop}] %b{%u_siteop} removed %b{%u_name} from group %b{%g_name}."
+announce.DEBUG                  = "[%b{debug }] %msg"
+announce.DELETED                = "[%b{siteop}] %b{%u_siteop} deleted user %b{%u_name}."
+announce.DELIP                  = "[%b{delip }] %b{%u_siteop} deleted IP %b{%u_ip} from %b{%u_name}."
+announce.DELUSER                = "[%b{siteop}] %b{%u_siteop} deleted user %b{%u_name}."
+announce.EXPIRED                = "[%b{siteop}] User %b{%u_name} has expired."
+announce.GADDUSER               = "[%b{siteop}] %b{%u_siteop} (group %g_siteop) added user %b{%u_name}."
+announce.IPNOTADDED             = "[%b{addip }] IP %b{%u_ip} could not be added to %b{%u_name} - maximum IPs reached."
+announce.KILLGHOST              = "[%b{ghost }] %b{%u_name} killed a ghost with PID %b{%u_pid}."
+announce.KILLED                 = "[%b{siteop}] %b{%u_siteop} killed user %b{%u_name}."
+announce.LOGIN                  = "[%b{login }] %b{%u_name} of %g_name has logged in."
+announce.LOGOUT                 = "[%b{logout}] %b{%u_name} of %g_name has logged out."
+announce.PURGED                 = "[%b{siteop}] %b{%u_siteop} purged user %b{%u_name}."
+announce.READDED                = "[%b{siteop}] %b{%u_siteop} readded user %b{%u_name}."
+announce.SYSOP                  = "[%b{sysop }] %b{%u_name} of %g_name did a sysop thing."
+announce.TAGLINE                = "[%b{taglin}] %b{%u_name} changed tagline to: %b{%u_tagline}."
+announce.TIMEOUT                = "[%b{logout}] %b{%u_name} of %g_name timed out after %b{%u_idletime}."
+announce.WIPE                   = "[%b{wipe  }] %b{%u_name} of %g_name wiped: %b{%releasename}."
+announce.WIPE-r                 = "[%b{wipe-r}] %b{%u_name} of %g_name recursively wiped: %b{%releasename}."

--- a/zipscript/include/convert.h
+++ b/zipscript/include/convert.h
@@ -1,7 +1,7 @@
 #ifndef _CONVERT_H_
 #define _CONVERT_H_
 
-char *hms(char *, int);
+char *hms(char *, double);
 char *convert(struct VARS *, struct USERINFO **, struct GROUPINFO **, char *);
 char *convert_user(struct VARS *, struct USERINFO *, struct GROUPINFO **, char *, short);
 char *convert_group(struct VARS *, struct GROUPINFO *, char *, short);

--- a/zipscript/include/objects.h
+++ b/zipscript/include/objects.h
@@ -113,8 +113,8 @@ struct current_file {
 };
 
 struct race_total {
-	unsigned int	start_time;
-	unsigned int	stop_time;
+	struct timeval	start_time;
+	struct timeval	stop_time;
 	unsigned char	users;
 	unsigned char	groups;
 	int		files;

--- a/zipscript/include/race-file.h
+++ b/zipscript/include/race-file.h
@@ -9,12 +9,9 @@
 /* this is what we write to racedata files */
 typedef struct {
 	unsigned int	crc32,
-			speed; /* should become unsigned long, but causes
-				* backwards incompatibility; might be overcome
-				* via sfv_version checking when using readrace()
-				*/
+			speed;
 	off_t		size;
-	time_t		start_time;
+	struct timeval	start_time;
 	unsigned char	status;
 	unsigned char	dummy1;
 	char		fname[NAMEMAX],

--- a/zipscript/include/stats.h
+++ b/zipscript/include/stats.h
@@ -10,7 +10,7 @@ struct userdata {
 };
 
 void updatestats_free(GLOBAL *);
-void updatestats(struct VARS *, struct USERINFO **, struct GROUPINFO **, char *, char *, off_t, unsigned long, unsigned int);
+void updatestats(struct VARS *, struct USERINFO **, struct GROUPINFO **, char *, char *, off_t, unsigned long, struct timeval);
 void sortstats(struct VARS *, struct USERINFO **, struct GROUPINFO **);
 void showstats(struct VARS *, struct USERINFO **, struct GROUPINFO **);
 void get_stats(struct VARS *, struct USERINFO **);

--- a/zipscript/include/zsconfig.defaults.h
+++ b/zipscript/include/zsconfig.defaults.h
@@ -375,6 +375,11 @@
 #define debug_mode                                FALSE
 #endif
 
+#ifndef time_precision
+#define time_precision_is_defaulted
+#define time_precision                            3
+#endif
+
 #ifndef del_audio_completebar
 #define del_audio_completebar_is_defaulted
 #define del_audio_completebar                     "^\\[.*] - \\( .*F - COMPLETE - .*) - \\[.*]$"

--- a/zipscript/src/Makefile.in
+++ b/zipscript/src/Makefile.in
@@ -6,8 +6,7 @@ using_glftpd=@USING_GLFTPD@
 
 CC=@CC@
 CFLAGS=@CFLAGS@ @STATIC@ @NOFORMAT@ @USING_GLFTPD@ @GLVERSION@ @FLAC_HEADERS@ -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE @DEFS@ -I../include/ -I../../ -I../../lib/
-LDFLAGS=@LDFLAGS@
-LIBS=@LIBS@
+LDFLAGS=@LDFLAGS@ -lm
 RM=@RM@ -f
 INSTALL=@INSTALL@
 STRLCPY=../../lib/strl/strlcpy.o
@@ -34,42 +33,42 @@ all: postunnuke ng-undupe ng-deldir zipscript-c postdel racestats cleanup datacl
 $(ZS-DEPEND): ../conf/zsconfig.h
 
 strsep.o:
-	$(CC) $(CFLAGS) -o strsep.o -c strsep.c $(LIBS) $(LDFLAGS)
+	$(CC) $(CFLAGS) -o strsep.o -c strsep.c
 scandir.o:
-	$(CC) $(CFLAGS) -o scandir.o -c scandir.c $(LIBS) $(LDFLAGS)
+	$(CC) $(CFLAGS) -o scandir.o -c scandir.c
 
 zipscript-c: $(ZS-OBJECTS) $(ZS-DEPEND) $(SUNOBJS)
-	$(CC) $(CFLAGS) -o $@ $(ZS-OBJECTS) $(SUNOBJS) $(LIBS) $(LDFLAGS)
+	$(CC) $(CFLAGS) -o $@ $(ZS-OBJECTS) $(SUNOBJS) $(LDFLAGS)
 
 postdel: $(PD-OBJECTS)
-	$(CC) $(CFLAGS) -o $@ $(PD-OBJECTS) $(LIBS) $(LDFLAGS)
+	$(CC) $(CFLAGS) -o $@ $(PD-OBJECTS) $(LDFLAGS)
 
 racestats: $(RS-OBJECTS)
-	$(CC) $(CFLAGS) -o $@ $(RS-OBJECTS) $(LIBS) $(LDFLAGS)
+	$(CC) $(CFLAGS) -o $@ $(RS-OBJECTS)
 
 cleanup: $(CU-OBJECTS)
-	$(CC) $(CFLAGS) -o $@ $(CU-OBJECTS) $(SUNOBJS) $(LIBS) $(LDFLAGS)
+	$(CC) $(CFLAGS) -o $@ $(CU-OBJECTS) $(SUNOBJS)
 
 datacleaner: $(DC-OBJECTS)
-	$(CC) $(CFLAGS) -o $@ $(DC-OBJECTS) $(SUNOBJS) $(LIBS) $(LDFLAGS)
+	$(CC) $(CFLAGS) -o $@ $(DC-OBJECTS) $(SUNOBJS)
 
 ng-undupe: $(UD-OBJECTS)
-	$(CC) $(CFLAGS) -o $@ $(UD-OBJECTS) $(LIBS) $(LDFLAGS)
+	$(CC) $(CFLAGS) -o $@ $(UD-OBJECTS)
 
 ng-deldir: $(DD-OBJECTS)
-	$(CC) $(CFLAGS) -o $@ $(DD-OBJECTS) $(LIBS) $(LDFLAGS)
+	$(CC) $(CFLAGS) -o $@ $(DD-OBJECTS)
 
 ng-chown: $(CH-OBJECTS)
-	$(CC) $(CFLAGS) -o $@ $(CH-OBJECTS) $(SUNOBJS) $(LIBS) $(LDFLAGS)
+	$(CC) $(CFLAGS) -o $@ $(CH-OBJECTS) $(SUNOBJS)
 
 audiosort: $(AS-OBJECTS)
-	$(CC) $(CFLAGS) -o $@ $(AS-OBJECTS) $(LIBS) $(LDFLAGS)
+	$(CC) $(CFLAGS) -o $@ $(AS-OBJECTS) $(LDFLAGS)
 
 rescan: $(SC-OBJECTS)
-	$(CC) $(CFLAGS) -o $@ $(SC-OBJECTS) $(LIBS) $(LDFLAGS)
+	$(CC) $(CFLAGS) -o $@ $(SC-OBJECTS) $(LDFLAGS)
 
 postunnuke: $(PU-OBJECTS)
-	$(CC) $(CFLAGS) -o $@ $(PU-OBJECTS) $(LIBS) $(LDFLAGS)
+	$(CC) $(CFLAGS) -o $@ $(PU-OBJECTS) $(LDFLAGS)
 
 install:
 	if [ "x$(using_glftpd)" != "x" ] && [ ! -e "$(bindir)" ]; then exit 1; fi

--- a/zipscript/src/convert.c
+++ b/zipscript/src/convert.c
@@ -18,11 +18,25 @@ hms(char *ttime, double secs)
 	int tmp = 0;
 	int total_secs = (int)secs;
 	int millis = (int)((secs - total_secs) * 1000);
+	int hours = 0, mins = 0, remaining_secs;
 
 	tmp = sprintf(ttime, "%d", total_secs);
 	if (millis > 0)
 		tmp += sprintf(ttime + tmp, ",%03d", millis);
-	tmp += sprintf(ttime + tmp, "s");
+	tmp += sprintf(ttime + tmp, "s|");
+
+	remaining_secs = total_secs;
+	hours = remaining_secs / 3600;
+	remaining_secs %= 3600;
+	mins = remaining_secs / 60;
+	remaining_secs %= 60;
+
+	if (hours)
+		tmp += sprintf(ttime + tmp, "%ih", hours);
+	if (mins)
+		tmp += sprintf(ttime + tmp, "%im", mins);
+	if (remaining_secs || (!hours && !mins))
+		tmp += sprintf(ttime + tmp, "%is", remaining_secs);
 
 	return ttime;
 }

--- a/zipscript/src/postunnuke.c
+++ b/zipscript/src/postunnuke.c
@@ -274,7 +274,8 @@ main(int argc, char *argv[])
 				strlcpy(g.v.file.name, dp->d_name, NAME_MAX);
 				g.v.file.speed = 2005 * 1024;
 				g.v.file.size = fileinfo.st_size;
-				g.v.total.start_time = 0;
+				g.v.total.start_time.tv_sec = 0;
+				g.v.total.start_time.tv_usec = 0;
 
 				_err_file_banned(g.v.file.name, &g.v);
 				if (!fileexists("file_id.diz")) {
@@ -412,7 +413,8 @@ main(int argc, char *argv[])
 
 			return 0;
 		}
-		g.v.total.start_time = 0;
+		g.v.total.start_time.tv_sec = 0;
+		g.v.total.start_time.tv_usec = 0;
 		rewinddir(dir);
 		while ((dp = readdir(dir))) {
 			m = l = (int)strlen(dp->d_name);
@@ -460,13 +462,19 @@ main(int argc, char *argv[])
 				g.v.file.size = fileinfo.st_size;
 
 				temp_time = fileinfo.st_mtime;
-				
-				if (g.v.total.start_time == 0)
-					g.v.total.start_time = temp_time;
-				else
-					g.v.total.start_time = (g.v.total.start_time < temp_time ? g.v.total.start_time : temp_time);
-				
-				g.v.total.stop_time = (temp_time > g.v.total.stop_time ? temp_time : g.v.total.stop_time);
+
+				if (g.v.total.start_time.tv_sec == 0) {
+					g.v.total.start_time.tv_sec = temp_time;
+					g.v.total.start_time.tv_usec = 0;
+				} else if (temp_time < g.v.total.start_time.tv_sec) {
+					g.v.total.start_time.tv_sec = temp_time;
+					g.v.total.start_time.tv_usec = 0;
+				}
+
+				if (temp_time > g.v.total.stop_time.tv_sec) {
+					g.v.total.stop_time.tv_sec = temp_time;
+					g.v.total.stop_time.tv_usec = 0;
+				}
 
 				/* Hide users in group_dirs */
 				if (matchpath(group_dirs, g.l.path) && (hide_group_uploaders == TRUE)) {

--- a/zipscript/src/rescan.c
+++ b/zipscript/src/rescan.c
@@ -392,7 +392,8 @@ main(int argc, char *argv[])
 					strlcpy(g.v.file.name, dp->d_name, sizeof(g.v.file.name));
 					g.v.file.speed = 2005 * 1024;
 					g.v.file.size = fileinfo.st_size;
-					g.v.total.start_time = 0;
+					g.v.total.start_time.tv_sec = 0;
+					g.v.total.start_time.tv_usec = 0;
 					_err_file_banned(g.v.file.name, &g.v);
 #if (test_for_password || extract_nfo)
 					tempstream = telldir(dir);
@@ -568,7 +569,8 @@ main(int argc, char *argv[])
 
 			return 0;
 		}
-		g.v.total.start_time = 0;
+		g.v.total.start_time.tv_sec = 0;
+		g.v.total.start_time.tv_usec = 0;
 		rewinddir(dir);
 		while ((dp = readdir(dir))) {
 			if (*one_name && strncasecmp(one_name, dp->d_name, strlen(one_name)))
@@ -632,12 +634,18 @@ main(int argc, char *argv[])
 
 				temp_time = fileinfo.st_mtime;
 
-				if (g.v.total.start_time == 0)
-					g.v.total.start_time = temp_time;
-				else
-					g.v.total.start_time = (g.v.total.start_time < temp_time ? g.v.total.start_time : temp_time);
+				if (g.v.total.start_time.tv_sec == 0) {
+					g.v.total.start_time.tv_sec = temp_time;
+					g.v.total.start_time.tv_usec = 0;
+				} else if (temp_time < g.v.total.start_time.tv_sec) {
+					g.v.total.start_time.tv_sec = temp_time;
+					g.v.total.start_time.tv_usec = 0;
+				}
 
-				g.v.total.stop_time = (temp_time > g.v.total.stop_time ? temp_time : g.v.total.stop_time);
+				if (temp_time > g.v.total.stop_time.tv_sec) {
+					g.v.total.stop_time.tv_sec = temp_time;
+					g.v.total.stop_time.tv_usec = 0;
+				}
 
 				/* Hide users in group_dirs */
 				if (matchpath(group_dirs, g.l.path) && (hide_group_uploaders == TRUE)) {

--- a/zipscript/src/stats.c
+++ b/zipscript/src/stats.c
@@ -42,8 +42,8 @@ updatestats_free(GLOBAL *g)
  * Description: Updates existing entries in userI and groupI or creates new, if
  * old doesnt exist
  */
-void 
-updatestats(struct VARS *raceI, struct USERINFO **userI, struct GROUPINFO **groupI, char *usern, char *group, off_t filesize, unsigned long speed, unsigned int start_time)
+void
+updatestats(struct VARS *raceI, struct USERINFO **userI, struct GROUPINFO **groupI, char *usern, char *group, off_t filesize, unsigned long speed, struct timeval start_time)
 {
 	int		u_no = -1;
 	int		g_no = -1;
@@ -60,13 +60,10 @@ updatestats(struct VARS *raceI, struct USERINFO **userI, struct GROUPINFO **grou
 	if (u_no == -1) {
 		if (!raceI->total.users) {
 			raceI->total.start_time = start_time;
-			/*
-			 * to prevent a possible floating point exception in
-			 * convert,
-			 */
-			/* if first entry in racefile is not the oldest one           */
-			if ((int)(raceI->total.stop_time - raceI->total.start_time) < 1)
-				raceI->total.stop_time = raceI->total.start_time + 1;
+			if ((raceI->total.stop_time.tv_sec - raceI->total.start_time.tv_sec) < 1) {
+				raceI->total.stop_time.tv_sec = raceI->total.start_time.tv_sec + 1;
+				raceI->total.stop_time.tv_usec = raceI->total.start_time.tv_usec;
+			}
 		}
 		u_no = raceI->total.users++;
 		ng_free(userI[u_no]);

--- a/zipscript/src/zipscript-c.c
+++ b/zipscript/src/zipscript-c.c
@@ -417,20 +417,26 @@ main(int argc, char **argv)
 	if (stat(g.v.file.name, &fileinfo)) {
 		d_log("zipscript-c: Failed to stat file: %s\n", strerror(errno));
 		g.v.file.size = 0;
-		g.v.total.stop_time = 0;
+		gettimeofday(&g.v.total.stop_time, NULL);
 	} else {
 		g.v.file.size = fileinfo.st_size;
 		d_log("zipscript-c: File size was: %d\n", g.v.file.size);
-		g.v.total.stop_time = fileinfo.st_mtime;
+		gettimeofday(&g.v.total.stop_time, NULL);
 	}
 
 	d_log("zipscript-c: Setting race times\n");
-	if (g.v.file.size != 0)
-		g.v.total.start_time = g.v.total.stop_time - ((unsigned int)(g.v.file.size) / g.v.file.speed);
-	else
-		g.v.total.start_time = g.v.total.stop_time > (g.v.total.stop_time - 1) ? g.v.total.stop_time : (g.v.total.stop_time -1);
-	if ((int)(g.v.total.stop_time - g.v.total.start_time) < 1)
-		g.v.total.stop_time = g.v.total.start_time + 1;
+	if (g.v.file.size != 0) {
+		unsigned int duration_sec = (unsigned int)(g.v.file.size) / g.v.file.speed;
+		g.v.total.start_time.tv_sec = g.v.total.stop_time.tv_sec - duration_sec;
+		g.v.total.start_time.tv_usec = g.v.total.stop_time.tv_usec;
+	} else {
+		g.v.total.start_time.tv_sec = g.v.total.stop_time.tv_sec - 1;
+		g.v.total.start_time.tv_usec = g.v.total.stop_time.tv_usec;
+	}
+	if ((g.v.total.stop_time.tv_sec - g.v.total.start_time.tv_sec) < 1) {
+		g.v.total.stop_time.tv_sec = g.v.total.start_time.tv_sec + 1;
+		g.v.total.stop_time.tv_usec = g.v.total.start_time.tv_usec;
+	}
 
 	n = (g.l.length_path = (int)strlen(g.l.path)) + 1;
 


### PR DESCRIPTION
This PR adds configurable millisecond precision to race timing output.

Features:
- New \t_time_ms\ variable with configurable decimal precision (1-6 digits)
- New \t_time_ms_legacy\ for backwards compatibility (old format + ms)
- Configurable via new \time_precision\ setting in zsconfig
- Proper decimal point formatting for different locales
- Updates to zipscript-c, stats, race-file for timing calculations
- Updates to ngBot constants and themes
- Adds -lm linker flag for math library (pow function)

The timing is calculated from actual file timestamps with microsecond precision where available.