### PR TITLE
Add time precision

### DIFF
--- a/README.ZSCONFIG
+++ b/README.ZSCONFIG
@@ -507,6 +507,22 @@ debug_mode <TRUE|FALSE>
 	Related option(s): debug_altlog debug_announce
 	Default: FALSE
 
+time_precision <INTEGER>
+	Number of decimal places to show for seconds in duration output.
+	Valid values: 0-3
+	0 = no decimal places (82s, 1m22s)
+	1 = one decimal place (82.3s, 1m22.3s)
+	2 = two decimal places (82.39s, 1m22.39s)
+	3 = three decimal places for milliseconds (82.396s, 1m22.396s)
+	Default: 3
+
+time_format_seconds_only <TRUE|FALSE>
+	Determines if the duration is shown in total seconds only or in
+	Hours/Minutes/Seconds format.
+	TRUE  = 71.276s
+	FALSE = 1m11.276s
+	Default: FALSE
+
 del_banned_release <TRUE|FALSE>
 	If you want to make absolutely sure the banned release does not take up
 	more bandwith or space than necessary, you can choose to completely
@@ -1746,4 +1762,3 @@ zsinternal_checks_completed <STRING>
 	Output in benchmark mode.
 	In default value, %0.6f = six digits number of seconds.
 	Default: "Checks completed in %0.6f seconds.\n"
-

--- a/zipscript/conf/zsconfig.h.dist
+++ b/zipscript/conf/zsconfig.h.dist
@@ -32,6 +32,13 @@
 #define debug_mode                   FALSE
 #define debug_altlog                 TRUE
 
+/* 
+ * Show duration in seconds only?
+ * TRUE  = 71.276s
+ * FALSE = 1m11.276s
+ */
+#define time_format_seconds_only     FALSE
+
 #define status_bar_type              BAR_DIR
 #define incompleteislink             TRUE
 

--- a/zipscript/conf/zsconfig.h.dist-nonglftpd
+++ b/zipscript/conf/zsconfig.h.dist-nonglftpd
@@ -29,6 +29,13 @@
 #define debug_mode                   FALSE
 #define debug_altlog                 TRUE
 
+/* 
+ * Show duration in seconds only?
+ * TRUE  = 71.276s
+ * FALSE = 1m11.276s
+ */
+#define time_format_seconds_only     FALSE
+
 #define status_bar_type              BAR_DIR
 #define incompleteislink             TRUE
 

--- a/zipscript/conf/zsconfig.h.ss5.dist
+++ b/zipscript/conf/zsconfig.h.ss5.dist
@@ -32,6 +32,13 @@
 #define ignored_types			",diz,debug,message,imdb"
 
 #define debug_mode			TRUE
+
+/* 
+ * Show duration in seconds only?
+ * TRUE  = 71.276s
+ * FALSE = 1m11.276s
+ */
+#define time_format_seconds_only     FALSE
 #define remove_dot_files_on_delete	FALSE
 #define remove_dot_debug_on_delete	TRUE
 
@@ -67,4 +74,3 @@
 
 #define max_users_in_top		12
 #define max_groups_in_top		6
-

--- a/zipscript/include/convert.h
+++ b/zipscript/include/convert.h
@@ -1,7 +1,7 @@
 #ifndef _CONVERT_H_
 #define _CONVERT_H_
 
-char *hms(char *, int);
+char *hms(char *, double);
 char *convert(struct VARS *, struct USERINFO **, struct GROUPINFO **, char *);
 char *convert_user(struct VARS *, struct USERINFO *, struct GROUPINFO **, char *, short);
 char *convert_group(struct VARS *, struct GROUPINFO *, char *, short);

--- a/zipscript/include/objects.h
+++ b/zipscript/include/objects.h
@@ -113,8 +113,8 @@ struct current_file {
 };
 
 struct race_total {
-	unsigned int	start_time;
-	unsigned int	stop_time;
+	struct timeval	start_time;
+	struct timeval	stop_time;
 	unsigned char	users;
 	unsigned char	groups;
 	int		files;

--- a/zipscript/include/objects.h
+++ b/zipscript/include/objects.h
@@ -189,6 +189,6 @@ typedef struct {
 /* sfv_version - must be > 5. Should not be any need to add a version
  * for racedata - if either sfv_data or racedata changes, they both
  * should be removed */
-#define sfv_version	17
+#define sfv_version	18
 
 #endif

--- a/zipscript/include/race-file.h
+++ b/zipscript/include/race-file.h
@@ -3,6 +3,7 @@
 
 #include <stdbool.h>
 #include <sys/stat.h>
+#include <sys/time.h>
 #include "objects.h"
 #include "zsfunctions.h"
 
@@ -14,7 +15,7 @@ typedef struct {
 				* via sfv_version checking when using readrace()
 				*/
 	off_t		size;
-	time_t		start_time;
+	struct timeval	start_time;
 	unsigned char	status;
 	unsigned char	dummy1;
 	char		fname[NAMEMAX],
@@ -71,4 +72,3 @@ extern int read_headdata(const char *);
 extern bool create_lock_link(struct VARS *);
 extern void remove_lock_link(struct VARS *);
 #endif
-

--- a/zipscript/include/stats.h
+++ b/zipscript/include/stats.h
@@ -10,7 +10,7 @@ struct userdata {
 };
 
 void updatestats_free(GLOBAL *);
-void updatestats(struct VARS *, struct USERINFO **, struct GROUPINFO **, char *, char *, off_t, unsigned long, unsigned int);
+void updatestats(struct VARS *, struct USERINFO **, struct GROUPINFO **, char *, char *, off_t, unsigned long, struct timeval);
 void sortstats(struct VARS *, struct USERINFO **, struct GROUPINFO **);
 void showstats(struct VARS *, struct USERINFO **, struct GROUPINFO **);
 void get_stats(struct VARS *, struct USERINFO **);

--- a/zipscript/include/zsconfig.defaults.h
+++ b/zipscript/include/zsconfig.defaults.h
@@ -375,6 +375,16 @@
 #define debug_mode                                FALSE
 #endif
 
+#ifndef time_precision
+#define time_precision_is_defaulted
+#define time_precision                            3
+#endif
+
+#ifndef time_format_seconds_only
+#define time_format_seconds_only_is_defaulted
+#define time_format_seconds_only                  FALSE
+#endif
+
 #ifndef del_audio_completebar
 #define del_audio_completebar_is_defaulted
 #define del_audio_completebar                     "^\\[.*] - \\( .*F - COMPLETE - .*) - \\[.*]$"
@@ -1434,4 +1444,3 @@
 #define zsinternal_checks_completed_is_defaulted
 #define zsinternal_checks_completed               "Checks completed in %0.6f seconds.\n"
 #endif
-

--- a/zipscript/src/convert.c
+++ b/zipscript/src/convert.c
@@ -3,6 +3,7 @@
 #include <sys/types.h>
 #include <ctype.h>
 #include <time.h>
+#include <math.h>
 #include "objects.h"
 #include "zsfunctions.h"
 #include "../conf/zsconfig.h"
@@ -12,33 +13,34 @@
 
 char output[2048], output2[1024];
 
-/*
- * char *hms(char *ttime, int secs)
- * 
- * Converts source integer to bolded time string.
- * 
- */
 char *
-hms(char *ttime, int secs)
+hms(char *ttime, double secs)
 {
-	int		hours = 0,	mins = 0, tmp = 0;
+	int tmp = 0;
+	int total_secs = (int)secs;
+	double fractional = secs - total_secs;
+	int hours = 0, mins = 0, remaining_secs;
 
-	while (secs >= 3600) {
-		hours++;
-		secs -= 3600;
-	}
-	while (secs >= 60) {
-		mins++;
-		secs -= 60;
-	}
+	remaining_secs = total_secs;
+	hours = remaining_secs / 3600;
+	remaining_secs %= 3600;
+	mins = remaining_secs / 60;
+	remaining_secs %= 60;
 
 	if (hours)
-		tmp = sprintf(ttime, "%ih", (int)hours);
+		tmp += sprintf(ttime + tmp, "%ih", hours);
 	if (mins)
-		tmp += sprintf(ttime + tmp, "%im", (int)mins);
-	if (secs || !tmp)
-		tmp += sprintf(ttime + tmp, "%is", (int)secs);
-	
+		tmp += sprintf(ttime + tmp, "%im", mins);
+	if (remaining_secs || (!hours && !mins)) {
+		tmp += sprintf(ttime + tmp, "%i", remaining_secs);
+		if (time_precision > 0 && fractional > 0) {
+			char format[16];
+			sprintf(format, ".%%0%dd", time_precision);
+			tmp += sprintf(ttime + tmp, format, (int)(fractional * pow(10, time_precision)));
+		}
+		tmp += sprintf(ttime + tmp, "s");
+	}
+
 	return ttime;
 }
 
@@ -513,8 +515,11 @@ convert(struct VARS *raceI, struct USERINFO **userI, struct GROUPINFO **groupI, 
 				out_p += sprintf(out_p, "%*.*f", val1, val2, (double)(raceI->total.speed / 1024. / raceI->total.files));
 				break;
 			case 'A':
-				out_p += sprintf(out_p, "%*.*f", val1, val2,
-						 (double)((raceI->total.size / (raceI->total.stop_time - raceI->total.start_time)) / 1024.));
+			{
+				double duration_sec = (raceI->total.stop_time.tv_sec - raceI->total.start_time.tv_sec) +
+					(raceI->total.stop_time.tv_usec - raceI->total.start_time.tv_usec) / 1000000.0;
+				out_p += sprintf(out_p, "%*.*f", val1, val2, (double)((raceI->total.size / duration_sec) / 1024.));
+			}
 				break;
 			case 'b':
 				out_p += sprintf(out_p, "%*u", val1, (unsigned int)raceI->total.size);
@@ -603,11 +608,23 @@ convert(struct VARS *raceI, struct USERINFO **userI, struct GROUPINFO **groupI, 
 				instr--;
 				break;
 			case 'd':
-				out_p += sprintf(out_p, "%*.*s", val1, val2, (char *)hms(ttime, raceI->total.stop_time - raceI->total.start_time));
+			{
+				double duration_sec = (raceI->total.stop_time.tv_sec - raceI->total.start_time.tv_sec) +
+					(raceI->total.stop_time.tv_usec - raceI->total.start_time.tv_usec) / 1000000.0;
+#if ( time_format_seconds_only == TRUE )
+				out_p += sprintf(out_p, "%*.*f", val1, val2, duration_sec);
+#else
+				out_p += sprintf(out_p, "%*.*s", val1, val2, (char *)hms(ttime, duration_sec));
+#endif
+			}
 				break;
 			case '$':
-				out_p += sprintf(out_p, "%*.*s", val1, val2,
-						 (char *)hms(ttime, (((((raceI->total.stop_time - raceI->total.start_time) + (raceI->total.files - raceI->total.files_missing) > 0 ? (raceI->total.stop_time - raceI->total.start_time) + (raceI->total.files - raceI->total.files_missing) : 1 )) / (raceI->total.files - raceI->total.files_missing)) * raceI->total.files) - (raceI->total.stop_time - raceI->total.start_time)));
+			{
+				double duration_sec = (raceI->total.stop_time.tv_sec - raceI->total.start_time.tv_sec) +
+					(raceI->total.stop_time.tv_usec - raceI->total.start_time.tv_usec) / 1000000.0;
+				double eta_sec = ((((duration_sec + (raceI->total.files - raceI->total.files_missing) > 0 ? duration_sec + (raceI->total.files - raceI->total.files_missing) : 1)) / (raceI->total.files - raceI->total.files_missing)) * raceI->total.files) - duration_sec;
+				out_p += sprintf(out_p, "%*.*s", val1, val2, (char *)hms(ttime, eta_sec));
+			}
 				break;
 			case '&':
 				out_p += sprintf(out_p, "%llu", (unsigned long long)time(0));

--- a/zipscript/src/postunnuke.c
+++ b/zipscript/src/postunnuke.c
@@ -274,7 +274,8 @@ main(int argc, char *argv[])
 				strlcpy(g.v.file.name, dp->d_name, NAME_MAX);
 				g.v.file.speed = 2005 * 1024;
 				g.v.file.size = fileinfo.st_size;
-				g.v.total.start_time = 0;
+				g.v.total.start_time.tv_sec = 0;
+				g.v.total.start_time.tv_usec = 0;
 
 				_err_file_banned(g.v.file.name, &g.v);
 				if (!fileexists("file_id.diz")) {
@@ -412,7 +413,8 @@ main(int argc, char *argv[])
 
 			return 0;
 		}
-		g.v.total.start_time = 0;
+		g.v.total.start_time.tv_sec = 0;
+		g.v.total.start_time.tv_usec = 0;
 		rewinddir(dir);
 		while ((dp = readdir(dir))) {
 			m = l = (int)strlen(dp->d_name);
@@ -461,12 +463,18 @@ main(int argc, char *argv[])
 
 				temp_time = fileinfo.st_mtime;
 				
-				if (g.v.total.start_time == 0)
-					g.v.total.start_time = temp_time;
-				else
-					g.v.total.start_time = (g.v.total.start_time < temp_time ? g.v.total.start_time : temp_time);
-				
-				g.v.total.stop_time = (temp_time > g.v.total.stop_time ? temp_time : g.v.total.stop_time);
+				if (g.v.total.start_time.tv_sec == 0) {
+					g.v.total.start_time.tv_sec = temp_time;
+					g.v.total.start_time.tv_usec = 0;
+				} else if (temp_time < g.v.total.start_time.tv_sec) {
+					g.v.total.start_time.tv_sec = temp_time;
+					g.v.total.start_time.tv_usec = 0;
+				}
+
+				if (temp_time > g.v.total.stop_time.tv_sec) {
+					g.v.total.stop_time.tv_sec = temp_time;
+					g.v.total.stop_time.tv_usec = 0;
+				}
 
 				/* Hide users in group_dirs */
 				if (matchpath(group_dirs, g.l.path) && (hide_group_uploaders == TRUE)) {

--- a/zipscript/src/rescan.c
+++ b/zipscript/src/rescan.c
@@ -392,7 +392,8 @@ main(int argc, char *argv[])
 					strlcpy(g.v.file.name, dp->d_name, sizeof(g.v.file.name));
 					g.v.file.speed = 2005 * 1024;
 					g.v.file.size = fileinfo.st_size;
-					g.v.total.start_time = 0;
+					g.v.total.start_time.tv_sec = 0;
+					g.v.total.start_time.tv_usec = 0;
 					_err_file_banned(g.v.file.name, &g.v);
 #if (test_for_password || extract_nfo)
 					tempstream = telldir(dir);
@@ -568,7 +569,8 @@ main(int argc, char *argv[])
 
 			return 0;
 		}
-		g.v.total.start_time = 0;
+		g.v.total.start_time.tv_sec = 0;
+		g.v.total.start_time.tv_usec = 0;
 		rewinddir(dir);
 		while ((dp = readdir(dir))) {
 			if (*one_name && strncasecmp(one_name, dp->d_name, strlen(one_name)))
@@ -632,12 +634,18 @@ main(int argc, char *argv[])
 
 				temp_time = fileinfo.st_mtime;
 
-				if (g.v.total.start_time == 0)
-					g.v.total.start_time = temp_time;
-				else
-					g.v.total.start_time = (g.v.total.start_time < temp_time ? g.v.total.start_time : temp_time);
+				if (g.v.total.start_time.tv_sec == 0) {
+					g.v.total.start_time.tv_sec = temp_time;
+					g.v.total.start_time.tv_usec = 0;
+				} else if (temp_time < g.v.total.start_time.tv_sec) {
+					g.v.total.start_time.tv_sec = temp_time;
+					g.v.total.start_time.tv_usec = 0;
+				}
 
-				g.v.total.stop_time = (temp_time > g.v.total.stop_time ? temp_time : g.v.total.stop_time);
+				if (temp_time > g.v.total.stop_time.tv_sec) {
+					g.v.total.stop_time.tv_sec = temp_time;
+					g.v.total.stop_time.tv_usec = 0;
+				}
 
 				/* Hide users in group_dirs */
 				if (matchpath(group_dirs, g.l.path) && (hide_group_uploaders == TRUE)) {

--- a/zipscript/src/stats.c
+++ b/zipscript/src/stats.c
@@ -42,8 +42,8 @@ updatestats_free(GLOBAL *g)
  * Description: Updates existing entries in userI and groupI or creates new, if
  * old doesnt exist
  */
-void 
-updatestats(struct VARS *raceI, struct USERINFO **userI, struct GROUPINFO **groupI, char *usern, char *group, off_t filesize, unsigned long speed, unsigned int start_time)
+void
+updatestats(struct VARS *raceI, struct USERINFO **userI, struct GROUPINFO **groupI, char *usern, char *group, off_t filesize, unsigned long speed, struct timeval start_time)
 {
 	int		u_no = -1;
 	int		g_no = -1;
@@ -60,13 +60,10 @@ updatestats(struct VARS *raceI, struct USERINFO **userI, struct GROUPINFO **grou
 	if (u_no == -1) {
 		if (!raceI->total.users) {
 			raceI->total.start_time = start_time;
-			/*
-			 * to prevent a possible floating point exception in
-			 * convert,
-			 */
-			/* if first entry in racefile is not the oldest one           */
-			if ((int)(raceI->total.stop_time - raceI->total.start_time) < 1)
-				raceI->total.stop_time = raceI->total.start_time + 1;
+			if ((raceI->total.stop_time.tv_sec - raceI->total.start_time.tv_sec) < 1) {
+				raceI->total.stop_time.tv_sec = raceI->total.start_time.tv_sec + 1;
+				raceI->total.stop_time.tv_usec = raceI->total.start_time.tv_usec;
+			}
 		}
 		u_no = raceI->total.users++;
 		ng_free(userI[u_no]);

--- a/zipscript/src/zipscript-c.c
+++ b/zipscript/src/zipscript-c.c
@@ -417,20 +417,26 @@ main(int argc, char **argv)
 	if (stat(g.v.file.name, &fileinfo)) {
 		d_log("zipscript-c: Failed to stat file: %s\n", strerror(errno));
 		g.v.file.size = 0;
-		g.v.total.stop_time = 0;
+		gettimeofday(&g.v.total.stop_time, NULL);
 	} else {
 		g.v.file.size = fileinfo.st_size;
 		d_log("zipscript-c: File size was: %d\n", g.v.file.size);
-		g.v.total.stop_time = fileinfo.st_mtime;
+		gettimeofday(&g.v.total.stop_time, NULL);
 	}
 
 	d_log("zipscript-c: Setting race times\n");
-	if (g.v.file.size != 0)
-		g.v.total.start_time = g.v.total.stop_time - ((unsigned int)(g.v.file.size) / g.v.file.speed);
-	else
-		g.v.total.start_time = g.v.total.stop_time > (g.v.total.stop_time - 1) ? g.v.total.stop_time : (g.v.total.stop_time -1);
-	if ((int)(g.v.total.stop_time - g.v.total.start_time) < 1)
-		g.v.total.stop_time = g.v.total.start_time + 1;
+	if (g.v.file.size != 0) {
+		unsigned int duration_sec = (unsigned int)(g.v.file.size) / g.v.file.speed;
+		g.v.total.start_time.tv_sec = g.v.total.stop_time.tv_sec - duration_sec;
+		g.v.total.start_time.tv_usec = g.v.total.stop_time.tv_usec;
+	} else {
+		g.v.total.start_time.tv_sec = g.v.total.stop_time.tv_sec - 1;
+		g.v.total.start_time.tv_usec = g.v.total.stop_time.tv_usec;
+	}
+	if ((g.v.total.stop_time.tv_sec - g.v.total.start_time.tv_sec) < 1) {
+		g.v.total.stop_time.tv_sec = g.v.total.start_time.tv_sec + 1;
+		g.v.total.stop_time.tv_usec = g.v.total.start_time.tv_usec;
+	}
 
 	n = (g.l.length_path = (int)strlen(g.l.path)) + 1;
 
@@ -1967,4 +1973,3 @@ main(int argc, char **argv)
 	d_log("zipscript-c: Exit %d\n", exit_value);
 	return exit_value;
 }
-


### PR DESCRIPTION
  What:
  - Switch race timing to struct timeval for ms-precision.
  - Add time_precision (0–3) and time_format_seconds_only config options.
  - Update duration/ETA calculations to use sub-second timing.
  - Bump sfv_version to invalidate old racedata.

  Config:
  - New options in zsconfig.defaults.h and zsconfig.h.*.dist.
  - Documented in README.ZSCONFIG.
