### PR TITLE
Fix keyx_nick array access error on nick change in Blow.tcl

### DIFF
--- a/sitebot/plugins/Blow.tcl
+++ b/sitebot/plugins/Blow.tcl
@@ -352,9 +352,10 @@ namespace eval ::ngBot::plugin::Blow {
 		variable keyxqueue
 
 		foreach var [list "blowkey" "keyxinit" "keyxtimer" "keyxqueue"] {
-			if {[info exists $var($nick)]} {
-				set $var($newnick) $var($nick)
-				unset $var($nick)
+			upvar 0 $var arr
+			if {[info exists arr($nick)]} {
+				set arr($newnick) $arr($nick)
+				unset arr($nick)
 			}
 		}
 	}


### PR DESCRIPTION
fix(Blow.tcl): keyx_nick fails on nick change with "variable isn't array"
In sitebot/plugins/Blow.tcl, keyx_nick tries to move blowkey/keyxinit/
keyxtimer/keyxqueue entries from the old nick to the new nick on a NICK
event.

The existing code used $var($nick), which Tcl interprets as an array
access on the scalar loop variable `var`, causing:

    can't read "var(<oldnick>)": variable isn't array

every time a user changes nick while an entry for the old nick exists
in any of the keyx-related arrays. This can happen during an active
KEYX handshake or after a completed one, because blowkey($oldnick)
remains set.

Reproduction:
1. Enable key exchange in Blow.tcl (variable keyx true).
2. From an IRC client with FiSH/DH1080 support, start a private key
   exchange with the bot.
3. Change your nick while an entry for the old nick still exists.
   Eggdrop logs the above Tcl error for every bind nick event.

Fix by using `upvar 0 $var arr` to alias the dynamically named array and
access arr($nick) normally.