### PR TITLE
Sec: harden archive tool execution and helper input handling

### DIFF
--- a/zipscript/include/zsfunctions.h
+++ b/zipscript/include/zsfunctions.h
@@ -126,6 +126,7 @@ extern void	createlink(char *, char *, char *, char *);
 extern void	readsfv_ffile(struct VARS *);
 extern void	get_rar_info(char *, struct VARS *);
 extern int	execute(char *);
+extern int	execute_argv(char *const []);
 
 #ifdef USING_GLFTPD
 extern char    *get_g_name(int);

--- a/zipscript/src/datacleaner.c
+++ b/zipscript/src/datacleaner.c
@@ -28,6 +28,22 @@
 
 #include "datacleaner.h"
 
+static int
+has_parent_component(const char *path)
+{
+	const char	*p = path;
+
+	while (*p) {
+		while (*p == '/')
+			p++;
+		if (p[0] == '.' && p[1] == '.' && (p[2] == '/' || p[2] == '\0'))
+			return 1;
+		while (*p && *p != '/')
+			p++;
+	}
+	return 0;
+}
+
 int 
 main(int argc, char **argv)
 {
@@ -42,6 +58,14 @@ main(int argc, char **argv)
 		check_dir_loop(storage, zd_length);
 	} else {
 		if ((zd_length + 1 + (int)strlen(argv[1])) < PATH_MAX) {
+			if ( !strncmp(argv[1], "RMD ", 4) && has_parent_component(argv[1] + 4)) {
+				fprintf(stderr, "Unsafe path: %s\n", argv[1] + 4);
+				return 2;
+			}
+			if ( strncmp(argv[1], "RMD ", 4) && !strncmp(argv[1], "/", 1) && has_parent_component(argv[1])) {
+				fprintf(stderr, "Unsafe path: %s\n", argv[1]);
+				return 2;
+			}
 			if ( !strncmp(argv[1], "RMD ", 4)) {
 				/* script is called as a cscript for RMD */
 				if (!strncmp(argv[1] + 4, "/", 1)) {
@@ -69,6 +93,8 @@ main(int argc, char **argv)
 					free(wd);
 				}
 			}
+		} else {
+			return 2;
 		}
 		/* check subdirs */
 		check_dir_loop(st, zd_length);
@@ -152,4 +178,3 @@ check_dir_loop(char *path, int zd_length)
 	}
 	closedir(dir1);
 }
-

--- a/zipscript/src/postdel.c
+++ b/zipscript/src/postdel.c
@@ -363,10 +363,11 @@ main(int argc, char **argv)
 		if (!fileexists("file_id.diz")) {
 			temp_p = findfileext(dir, ".zip");
 			if (temp_p != NULL) {
+				char *unzip_diz_args[] = { unzip_bin, "-qqjnCLL", temp_p, "file_id.diz", NULL };
+
 				_err_file_banned(temp_p, &g.v);
 				d_log("postdel: file_id.diz does not exist, trying to extract it from %s\n", temp_p);
-				sprintf(target, "%s -qqjnCLL \"%s\" file_id.diz", unzip_bin, temp_p);
-				execute(target);
+				execute_argv(unzip_diz_args);
 				if (chmod("file_id.diz", 0666))
 					d_log("postdel: Failed to chmod %s: %s\n", "file_id.diz", strerror(errno));
 			}

--- a/zipscript/src/postunnuke.c
+++ b/zipscript/src/postunnuke.c
@@ -37,7 +37,7 @@
 int 
 main(int argc, char *argv[])
 {
-	int		k, n, m, l, complete_type = 0;
+	int		k, n, m, l, complete_type = 0, zip_status = 0;
 
 #ifdef USING_GLFTPD
         int             gnum = 0, unum = 0;
@@ -278,8 +278,9 @@ main(int argc, char *argv[])
 
 				_err_file_banned(g.v.file.name, &g.v);
 				if (!fileexists("file_id.diz")) {
-					sprintf(exec, "%s -qqjnCLL \"%s\" file_id.diz 2>.delme", unzip_bin, g.v.file.name);
-					if (execute(exec) != 0) {
+					char *unzip_diz_args[] = { unzip_bin, "-qqjnCLL", g.v.file.name, "file_id.diz", NULL };
+
+					if (execute_argv(unzip_diz_args) != 0) {
 						d_log("ng-post_unnuke: No file_id.diz found (#%d): %s\n", errno, strerror(errno));
 					} else {
 						if ((loc = findfile(dir, "file_id.diz.bad"))) {
@@ -291,8 +292,12 @@ main(int argc, char *argv[])
 							d_log("ng-post_unnuke: Failed to chmod %s: %s\n", "file_id.diz", strerror(errno));
 					}
 				}
-				sprintf(exec, "%s -qqt \"%s\" >.delme", unzip_bin, g.v.file.name);
-				if (system(exec) == 0) {
+				{
+					char *unzip_args[] = { unzip_bin, "-qqt", g.v.file.name, NULL };
+
+					zip_status = execute_argv(unzip_args);
+				}
+				if (zip_status == 0) {
 					writerace(g.l.race, &g.v, crc, F_CHECKED);
 				} else {
 					writerace(g.l.race, &g.v, crc, F_BAD);

--- a/zipscript/src/postunnuke.c
+++ b/zipscript/src/postunnuke.c
@@ -154,7 +154,7 @@ main(int argc, char *argv[])
 		snprintf(g.v.sectionname, 127, "%s", getenv("SECTION"));
 	}
 #else
-        snprintf(g.v.sectionname, 127, argv[8]);
+        snprintf(g.v.sectionname, sizeof(g.v.sectionname), "%s", argv[8]);
 #endif
 
 	g.l.race = ng_realloc2(g.l.race, n = (int)strlen(g.l.path) + 12 + sizeof(storage), 1, 1, 1);

--- a/zipscript/src/race-file.c
+++ b/zipscript/src/race-file.c
@@ -1467,7 +1467,7 @@ int
 check_zipfile(const char *dirname, const char *zipfile, int do_nfo)
 {
 	int             ret = 0;
-	char            path_buf[PATH_MAX], target[PATH_MAX];
+	char            path_buf[PATH_MAX];
 #if (extract_nfo)
 	char            nfo_buf[NAME_MAX];
 	time_t          t = 0;
@@ -1498,8 +1498,9 @@ check_zipfile(const char *dirname, const char *zipfile, int do_nfo)
 			if (!fileexists(zip_bin))
 				d_log("check_zipfile: ERROR! Not able to remove banned file from zip - zip_bin (%s) does not exist!\n", zip_bin);
 			else {
-				sprintf(target, "%s -qqd \"%s\" \"%s\"", zip_bin, zipfile, dp->d_name);
-				if (execute(target))
+				char *zip_args[] = { zip_bin, "-qqd", (char *)zipfile, dp->d_name, NULL };
+
+				if (execute_argv(zip_args))
 					d_log("check_zipfile: Failed to remove banned (%s) file from zip.\n", dp->d_name);
 			}
 			continue;

--- a/zipscript/src/rescan.c
+++ b/zipscript/src/rescan.c
@@ -37,7 +37,7 @@ void print_syntax(int chdir_allowed); /* Defined at the bottom of this file. */
 int 
 main(int argc, char *argv[])
 {
-	int		n, l, complete_type = 0, not_allowed = 0, argv_mode = 0;
+	int		n, l, complete_type = 0, not_allowed = 0, argv_mode = 0, zip_status = 0;
 
 #ifdef USING_GLFTPD
         int             gnum = 0, unum = 0;
@@ -396,15 +396,24 @@ main(int argc, char *argv[])
 					_err_file_banned(g.v.file.name, &g.v);
 #if (test_for_password || extract_nfo)
 					tempstream = telldir(dir);
-					if ((!findfileextcount(dir, ".nfo") || findfileextcount(dir, ".zip")) && !mkdir(".unzipped", 0777))
-						snprintf(exec, sizeof(exec), "%s -qqjo \"%s\" -d .unzipped 2>.delme", unzip_bin, g.v.file.name);
-					else
-						snprintf(exec, sizeof(exec), "%s -qqt \"%s\" 2>.delme", unzip_bin, g.v.file.name);
+					if ((!findfileextcount(dir, ".nfo") || findfileextcount(dir, ".zip")) && !mkdir(".unzipped", 0777)) {
+						char *unzip_args[] = { unzip_bin, "-qqjo", g.v.file.name, "-d", ".unzipped", NULL };
+
+						zip_status = execute_argv(unzip_args);
+					} else {
+						char *unzip_args[] = { unzip_bin, "-qqt", g.v.file.name, NULL };
+
+						zip_status = execute_argv(unzip_args);
+					}
 					seekdir(dir, tempstream);
 #else
-					snprintf(exec, sizeof(exec), "%s -qqt \"%s\" 2>.delme", unzip_bin, g.v.file.name);
+					{
+						char *unzip_args[] = { unzip_bin, "-qqt", g.v.file.name, NULL };
+
+						zip_status = execute_argv(unzip_args);
+					}
 #endif
-					if (system(exec) == 0 || (allow_error2_in_unzip == TRUE && errno < 3 )) {
+					if (zip_status == 0 || (allow_error2_in_unzip == TRUE && errno < 3 )) {
 						writerace(g.l.race, &g.v, crc, F_CHECKED);
 					} else {
 						writerace(g.l.race, &g.v, crc, F_BAD);
@@ -426,8 +435,9 @@ main(int argc, char *argv[])
 					seekdir(dir, tempstream);
 #endif
 					if (!fileexists("file_id.diz")) {
-						snprintf(exec, sizeof(exec), "%s -qqjnCLL \"%s\" file_id.diz 2>.delme", unzip_bin, g.v.file.name);
-						if (execute(exec) != 0) {
+						char *unzip_diz_args[] = { unzip_bin, "-qqjnCLL", g.v.file.name, "file_id.diz", NULL };
+
+						if (execute_argv(unzip_diz_args) != 0) {
 							d_log("rescan: No file_id.diz found (#%d): %s\n", errno, strerror(errno));
 						} else {
 							if (fileexists("file_id.diz.bad")) {

--- a/zipscript/src/rescan.c
+++ b/zipscript/src/rescan.c
@@ -233,7 +233,7 @@ main(int argc, char *argv[])
 		snprintf(g.v.sectionname, sizeof(g.v.sectionname), "%s", getenv("SECTION"));
 	}
 #else
-        snprintf(g.v.sectionname, sizeof(g.v.sectionname), argv[4]);
+        snprintf(g.v.sectionname, sizeof(g.v.sectionname), "%s", argv[4]);
 #endif
 
 	g.l.length_path = (int)strlen(g.l.path);

--- a/zipscript/src/zipscript-c.c
+++ b/zipscript/src/zipscript-c.c
@@ -117,6 +117,7 @@ main(int argc, char **argv)
 #endif
 
 	unsigned int	crc, s_crc = 0;
+	int		zip_status = 0;
 	unsigned char	exit_value = EXIT_SUCCESS;
 	unsigned char	no_check = FALSE;
 	unsigned char	do_not_del = FALSE;
@@ -685,14 +686,23 @@ main(int argc, char **argv)
 			} else {
 #if (test_for_password || extract_nfo)
 				if ((!findfileextcount(dir, ".nfo") ||
-				  findfileextcount(dir, ".zip")) && !mkdir(".unzipped", 0777))
-					sprintf(target, "%s -qqjo \"%s\" -d .unzipped", unzip_bin, g.v.file.name);
-				else
-					sprintf(target, "%s -qqt \"%s\"", unzip_bin, g.v.file.name);
+				  findfileextcount(dir, ".zip")) && !mkdir(".unzipped", 0777)) {
+					char *unzip_args[] = { unzip_bin, "-qqjo", g.v.file.name, "-d", ".unzipped", NULL };
+
+					zip_status = execute_argv(unzip_args);
+				} else {
+					char *unzip_args[] = { unzip_bin, "-qqt", g.v.file.name, NULL };
+
+					zip_status = execute_argv(unzip_args);
+				}
 #else
-				sprintf(target, "%s -qqt \"%s\"", unzip_bin, g.v.file.name);
+				{
+					char *unzip_args[] = { unzip_bin, "-qqt", g.v.file.name, NULL };
+
+					zip_status = execute_argv(unzip_args);
+				}
 #endif
-				if (execute(target) != 0 || (allow_error2_in_unzip == TRUE && errno > 2 )) {
+				if (zip_status != 0 || (allow_error2_in_unzip == TRUE && errno > 2 )) {
 					d_log("zipscript-c: Integrity check failed (#%d): %s\n", errno, strerror(errno));
 					sprintf(g.v.misc.error_msg, BAD_ZIP);
 					mark_as_bad(g.v.file.name);
@@ -743,9 +753,10 @@ main(int argc, char **argv)
 				}
 			}
 			if (!fileexists("file_id.diz")) {
+				char *unzip_diz_args[] = { unzip_bin, "-qqjnCLL", g.v.file.name, "file_id.diz", NULL };
+
 				d_log("zipscript-c: file_id.diz does not exist, trying to extract it from %s\n", g.v.file.name);
-				sprintf(target, "%s -qqjnCLL \"%s\" file_id.diz 2>.delme", unzip_bin, g.v.file.name);
-				if (execute(target) != 0)
+				if (execute_argv(unzip_diz_args) != 0)
 					d_log("zipscript-c: No file_id.diz found (#%d): %s\n", errno, strerror(errno));
 				else {
 					if ((loc = findfile(dir, "file_id.diz.bad"))) {
@@ -1937,4 +1948,3 @@ main(int argc, char **argv)
 	d_log("zipscript-c: Exit %d\n", exit_value);
 	return exit_value;
 }
-

--- a/zipscript/src/zipscript-c.c
+++ b/zipscript/src/zipscript-c.c
@@ -264,11 +264,11 @@ main(int argc, char **argv)
 #ifndef USING_GLFTPD
         d_log("zipscript-c: Reading data from commandline (ftpd-agnostic)\n");
         
-        sprintf(g.v.user.name, argv[3]);
-        sprintf(g.v.user.group, argv[4]);
+        snprintf(g.v.user.name, sizeof(g.v.user.name), "%s", argv[3]);
+        snprintf(g.v.user.group, sizeof(g.v.user.group), "%s", argv[4]);
         if (!(int)strlen(g.v.user.group))
                 memcpy(g.v.user.group, "NoGroup", 8);
-        sprintf(g.v.user.tagline, argv[5]);
+        snprintf(g.v.user.tagline, sizeof(g.v.user.tagline), "%s", argv[5]);
         if (!(int)strlen(g.v.user.tagline))
                 memcpy(g.v.user.tagline, "No Tagline Set", 15);
         g.v.file.speed = strtoul(argv[6], NULL, 0);
@@ -276,7 +276,7 @@ main(int argc, char **argv)
                 g.v.file.speed = 2005;
 
         d_log("zipscript-c: Reading section from arg (%s)\n", argv[7]);
-        snprintf(g.v.sectionname, 127, argv[7]);
+        snprintf(g.v.sectionname, sizeof(g.v.sectionname), "%s", argv[7]);
         g.v.section = 0;
 
         /* XXX We need a better way to handle this. wzd supports sections too.. ;-)
@@ -1937,4 +1937,3 @@ main(int argc, char **argv)
 	d_log("zipscript-c: Exit %d\n", exit_value);
 	return exit_value;
 }
-

--- a/zipscript/src/zsfunctions.c
+++ b/zipscript/src/zsfunctions.c
@@ -1198,6 +1198,30 @@ execute(char *s)
 	return i;
 }
 
+int
+execute_argv(char *const argv[])
+{
+	int	status = 0;
+	pid_t	pid;
+
+	pid = fork();
+	if (pid == -1) {
+		d_log("execute_argv: fork: %s\n", strerror(errno));
+		return -1;
+	}
+	if (pid == 0) {
+		execvp(argv[0], argv);
+		_exit(127);
+	}
+	while (waitpid(pid, &status, 0) == -1) {
+		if (errno != EINTR) {
+			d_log("execute_argv: waitpid: %s\n", strerror(errno));
+			return -1;
+		}
+	}
+	return status;
+}
+
 #ifdef USING_GLFTPD
 /* Only under glftpd do we have a uid/gid-lookup, so these
  * are only needed there. */


### PR DESCRIPTION
## Summary

- avoid shell expansion for built-in archive tool calls
- treat ftpd-agnostic arguments as plain strings
- reject traversal components in datacleaner paths

## Impact

Prevents command injection, format-string crashes, and unintended datacleaner cleanup outside the expected storage tree in affected configurations.
