### PR TITLE
SecFixes: path traversal, symlink race, command injection, and SSRF fixes 

### DIFF
--- a/scripts/psxc-trailer/psxc-trailer.sh
+++ b/scripts/psxc-trailer/psxc-trailer.sh
@@ -50,7 +50,21 @@
 #
 # What dirs to execute in (no wildcards). Use "/" to include all.
 # Example: validdirs="/site/MOVIES/ /site/FILMS/"
-validdirs="/"
+validdirs=""
+# Validate URLs derived from network responses
+url_is_safe() {
+  local url="$1"
+  case "$url" in
+    http://*|https://*)
+      return 0
+      ;;
+    *)
+      echo "Refusing unsafe URL: $url"
+      return 1
+      ;;
+  esac
+}
+
 
 # quality of trailer. Choose between
 # 320 (smallest), 480, 640, 480p, 720p, 1080p (highest)
@@ -212,7 +226,7 @@ let countdot=countdot-0
 while [ 1 ]; do
   releasenamedot="$(echo "$releasename" | sed $sedswitch "s/\.[12][0-9][0-9][0-9]\.*$//")"
   releasename="$(echo "$releasenamedot" | tr -d '\.' | sed $sedswitch "s/([dw]o|[sc][h]*a|[sw][h]*ould|must|[wh]a[sd]|did|are)(nt)/\1n't/g" )"
-  output="$(wget $wgetflags -o "$wgetoutput" -O - "http://www.apple.com/trailers/home/scripts/quickfind.php?q=$releasename")"
+  output="$(wget $wgetflags -o "$wgetoutput" -O - "https://www.apple.com/trailers/home/scripts/quickfind.php?q=$releasename")"
   outparse="$(echo $output | tr -d '\"' | tr ',' '\n')"
   iserror=$(echo $outparse | grep -i "error:true")
   isresult=$(echo $outparse | grep -i "results:\[\]")
@@ -251,7 +265,7 @@ releasenamespace=$(echo "$releasenamedot" | sed $sedswitch "s/(.*)\.$/\1/" | tr 
 poster=$(echo "$outparse" | grep -i "^poster:" | cut -d ':' -f 2- | tr -d '\\' | head -n 1)
 location="http://www.apple.com$(echo "$outparse" | grep -i "^location:" | cut -d ':' -f 2- | tr -d '\\' | tr ' ' '\n' | head -n 1)"
 
-output2="$(wget $wgetflags -o "$wgetoutput" -O - $location)"
+output2="$(wget $wgetflags -o "$wgetoutput" -O - "$location")"
 output2parse="$(echo $output2 | tr ' \?' '\n' | grep -v "/images/" | grep -E -i "^href=.*\.mov[\"]*$|^href=.*small[_]?.*\.html[\"]*|^href=.*medium[_]?.*\.html[\"]*|^href=.*large[_]?.*\.html[\"]*|^href=.*low[_]?.*\.html[\"]*|^href=.*high[_]?.*\.html[\"]?.*" | tr -d '\"' | cut -d '=' -f 2-)"
 #echo DEBUG 1: $output2parse
 #echo DEBUG 5: $location
@@ -316,7 +330,8 @@ done
     [[ "$downloadall" != "" ]] && {
       trailername=""
     }
-    wget $wgetflags -o "$wgetoutput" -O "$wgettemp" $urllink
+    url_is_safe "$urllink" || continue
+    wget $wgetflags -o "$wgetoutput" -O "$wgettemp" "$urllink"
     fakelinkname=$(echo $urllink | tr '/' '\n' | grep -i "\.mov$")
     reallinkname=$(cat "$wgettemp" | tr -c 'a-zA-Z0-9\-\.\_' '\n' | grep -i "\.mov" | sed "s|[Rr][Mm][Dd][Rr]||" | sed "
 s|^0||")
@@ -349,7 +364,8 @@ s|^0||")
       }
       chmod +w "$trailerdir"
     }
-    wget $wgetflags2 -o "$wgetoutput" -O ${trailerdir}${trailername} $reallink
+    url_is_safe "$reallink" || continue
+    wget $wgetflags2 -o "$wgetoutput" -O "${trailerdir}${trailername}" "$reallink"
 #    wget --ignore-length --timeout=10 -U "QuickTime/7.6.2 (qtver=7.6.2;os=Windows NT 5.1 Service Pack 3)" -o "$wgetoutput" -O ${trailerdir}${trailername} $reallink
     [[ ! -s "${trailerdir}${trailername}" ]] && {
       echo "For unknown reasons the script failed to download the trailer"
@@ -396,7 +412,8 @@ s|^0||")
     }
     chmod +w "$(dirname "$imagename")"
   }
-  wget $wgetflags -o "$wgetoutput" -O "$imagename" $poster
+  url_is_safe "$poster" || exit 1
+  wget $wgetflags -o "$wgetoutput" -O "$imagename" "$poster"
   [[ "$imagenameperms" != "" ]] && {
     chmod $imagenameperms "$imagename"
   }

--- a/zipscript/include/zsfunctions.h
+++ b/zipscript/include/zsfunctions.h
@@ -127,6 +127,8 @@ extern void	readsfv_ffile(struct VARS *);
 extern void	get_rar_info(char *, struct VARS *);
 extern int	execute(char *);
 extern int	execute_argv(char *const []);
+extern int	execute_hook(char *, char *);
+extern int	execute_cookies(char *, char *);
 
 #ifdef USING_GLFTPD
 extern char    *get_g_name(int);

--- a/zipscript/src/ng-chown.c
+++ b/zipscript/src/ng-chown.c
@@ -179,23 +179,34 @@ matchpath2(char *instr, char *path)
 	return 0;
 }
 
+static short int allowed_path(char *path)
+{
+	struct stat st;
+
+	if (matchpath2(group_dirs, path) || matchpath2(zip_dirs, path) || matchpath2(sfv_dirs, path)) {
+		if (lstat(path, &st) == 0 && S_ISLNK(st.st_mode))
+			return 0;
+		return 1;
+	}
+	return 0;
+}
+
 int 
 myscandir(char *my_path, char *my_name)
 {
+	if (!allowed_path(my_path)) {
+		printf("%s - Error: %s is not in allowed paths or is a symlink.\n", my_name, my_path);
+		return 1;
+	}
 	if (chdir(my_path) != -1) {
-		if (matchpath2(group_dirs, my_path) || matchpath2(zip_dirs, my_path) || matchpath2(sfv_dirs, my_path)) {
-			if (direntries > 0) {
-				while (direntries--) {
-					ng_free3(dirlist[direntries]);
-				}
-				ng_free3(dirlist);
+		if (direntries > 0) {
+			while (direntries--) {
+				ng_free3(dirlist[direntries]);
 			}
-			direntries = scandir(".", &dirlist, selector3, alphasort);
-			return 0;
-		} else {
-			printf("%s - Error: %s is not in allowed paths (group/zip/sfv-dirs).\n", my_name, my_path);
-			return 1;
+			ng_free3(dirlist);
 		}
+		direntries = scandir(".", &dirlist, selector3, alphasort);
+		return 0;
 	} else {
 		printf("%s - Error: Unable to chdir to %s : %s\n", my_name, my_path, strerror(errno));
 		return 1;
@@ -226,6 +237,10 @@ myscan(int my_result, int new_user, int new_group, int user_flag, int group_flag
 				}
 			}
 			if ((my_result == 0) && (dir_flag == 1)) {
+				if (!allowed_path(my_path)) {
+					printf("%s - Error: %s is not in allowed paths or is a symlink.\n", my_name, my_path);
+					return 1;
+				}
 				if (new_user != 0 && new_group != 0) {
 					if (chown(my_path, new_user, new_group) == -1) {
 						printf("%s - Warning: Failed to chown() %s: %s\n", my_name, my_path, strerror(errno));
@@ -238,6 +253,10 @@ myscan(int my_result, int new_user, int new_group, int user_flag, int group_flag
 		}
 	} else {
 		if (dir_flag == 1) {
+			if (!allowed_path(my_path)) {
+				printf("%s - Error: %s is not in allowed paths or is a symlink.\n", my_name, my_path);
+				return 1;
+			}
 			my_result = close(open(my_path, O_NONBLOCK));
 			if (my_result == 0) {
 				if (new_user != 0 && new_group != 0) {

--- a/zipscript/src/race-file.c
+++ b/zipscript/src/race-file.c
@@ -365,12 +365,11 @@ testfiles(struct LOCATIONS *locations, struct VARS *raceI, int rstatus)
 			if (!fileexists(unduper_script)) {
 				d_log("Failed to undupe '%s' - '%s' does not exist.\n", rd.fname, unduper_script);
 			} else {
-				sprintf(target, unduper_script " \"%s\"", rd.fname);
 				_err_file_banned(rd.fname, NULL);
-				if (execute(target) == 0)
-					d_log("testfiles: undupe of %s successful (%s).\n", rd.fname, target);
+				if (execute_hook(unduper_script, rd.fname) == 0)
+					d_log("testfiles: undupe of %s successful (%s).\n", rd.fname, unduper_script);
 				else
-					d_log("testfiles: undupe of %s failed (%s).\n", rd.fname, target);
+					d_log("testfiles: undupe of %s failed (%s).\n", rd.fname, unduper_script);
 			}
 #endif
 		}

--- a/zipscript/src/racestats.c
+++ b/zipscript/src/racestats.c
@@ -18,6 +18,27 @@
 #include "../conf/zsconfig.h"
 #include "../include/zsconfig.defaults.h"
 
+
+static int valid_rel_path(const char *p)
+{
+	const char *s;
+
+	if (!p || *p == '/' || strlen(p) >= PATH_MAX)
+		return 0;
+	if (strstr(p, ".."))
+		return 0;
+	for (s = p; *s; ) {
+		if (*s == '/') {
+			s++;
+			if (s[0] == '.' && s[1] == '/')
+				return 0;
+		} else {
+			s++;
+		}
+	}
+	return 1;
+}
+
 int 
 main(int argc, char **argv)
 {
@@ -49,7 +70,11 @@ main(int argc, char **argv)
 	g.v.file.name[0] = '.';
 	g.v.file.name[1] = 0;
 
-	strcpy(g.l.path, argv[1]);
+	if (!valid_rel_path(argv[1])) {
+		printf("%s: invalid path argument: %s\n", argv[0], argv[1]);
+		goto END;
+	}
+	snprintf(g.l.path, PATH_MAX, "%s", argv[1]);
 
 	n = strlen(g.l.path);
 	if (g.l.path[n] == '/') {

--- a/zipscript/src/rescan.c
+++ b/zipscript/src/rescan.c
@@ -815,9 +815,8 @@ main(int argc, char *argv[])
 			if (!fileexists(rescan_script)) {
 				d_log("rescan: Warning - rescan_script (%s) - file does not exist!\n", rescan_script);
 			} else {
-				snprintf(target, sizeof(target), rescan_script " \"%s\"", g.v.file.name);
 				_err_file_banned(g.v.file.name, &g.v);
-				if (execute(target) != 0)
+					if (execute_hook(rescan_script, g.v.file.name) != 0)
 					d_log("rescan: Failed to execute rescan_script: %s\n", strerror(errno));
 			}
 #endif

--- a/zipscript/src/zipscript-c.c
+++ b/zipscript/src/zipscript-c.c
@@ -656,8 +656,7 @@ main(int argc, char **argv)
 			d_log("zipscript-c: Executing sample_script (%s).\n", sample_script);
 			if (!fileexists(sample_script))
 				d_log("zipscript-c: Warning - sample_script (%s) - file does not exist!\n", sample_script);
-			sprintf(target, sample_script " \"%s\"", g.v.file.name);
-			if (execute(target) != 0)
+			if (execute_hook(sample_script, g.v.file.name) != 0)
 				d_log("zipscript-c: Failed to execute sample_script: %s\n", strerror(errno));
 		}
 	} else {
@@ -1014,8 +1013,7 @@ main(int argc, char **argv)
 				d_log("zipscript-c: Warning - nfo_script (%s) - file does not exist!\n", nfo_script);
 			}
 			d_log("zipscript-c: Executing nfo script (%s)\n", nfo_script);
-			sprintf(target, nfo_script " \"%s\"", g.v.file.name);
-			if (execute(target) != 0)
+			if (execute_hook(nfo_script, g.v.file.name) != 0)
 				d_log("zipscript-c: Failed to execute nfo_script: %s\n", strerror(errno));
 #endif
 
@@ -1070,8 +1068,7 @@ main(int argc, char **argv)
 								if (!fileexists(unduper_script)) {
 									d_log("zipscript-c: Warning - undupe script (%s) does not exist.\n", unduper_script);
 								}
-								sprintf(target, unduper_script " \"%s\"", g.v.file.name);
-								if (execute(target) == 0)
+								if (execute_hook(unduper_script, g.v.file.name) == 0)
 									d_log("zipscript-c: undupe of %s successful.\n", g.v.file.name);
 								else
 									d_log("zipscript-c: undupe of %s failed.\n", g.v.file.name);
@@ -1214,8 +1211,7 @@ main(int argc, char **argv)
 							d_log("zipscript-c: Warning -  audio_script (%s) - file does not exist!\n", audio_script);
 						}
 						d_log("zipscript-c: Executing audio script (%s %s)\n", audio_script, convert(&g.v, g.ui, g.gi, audio_script_cookies));
-						sprintf(target, "%s %s", audio_script, convert(&g.v, g.ui, g.gi, audio_script_cookies));
-						if (execute(target) != 0)
+												if (execute_cookies(audio_script, convert(&g.v, g.ui, g.gi, audio_script_cookies)) != 0)
 							d_log("zipscript-c: Failed to execute audio_script: %s\n", strerror(errno));
 					}
 					if (!matchpath(audio_nocheck_dirs, g.l.path)) {
@@ -1368,7 +1364,6 @@ main(int argc, char **argv)
 //						d_log("zipscript-c: Executing sample_script (%s).\n", sample_script);
 //						if (!fileexists(sample_script))
 //							d_log("zipscript-c: Warning - sample_script (%s) - file does not exist!\n", sample_script);
-//						sprintf(target, sample_script " \"%s\"", g.v.file.name);
 //						if (execute(target) != 0)
 //							d_log("zipscript-c: Failed to execute sample_script: %s\n", strerror(errno));
 //					}
@@ -1738,8 +1733,7 @@ main(int argc, char **argv)
 					d_log("zipscript-c: Warning - accept_script (%s) - file does not exist!\n", accept_script);
 				}
 				d_log("zipscript-c: Executing accept script (before complete_script)\n");
-				sprintf(target, accept_script " \"%s\"", g.v.file.name);
-				if (execute(target) != 0)
+				if (execute_hook(accept_script, g.v.file.name) != 0)
 					d_log("zipscript-c: Failed to execute accept_script: %s\n", strerror(errno));
 			}
 #endif
@@ -1748,8 +1742,7 @@ main(int argc, char **argv)
 				d_log("zipscript-c: Warning - complete_script (%s) - file does not exist!\n", complete_script);
 			}
 			d_log("zipscript-c: Executing complete script\n");
-			sprintf(target, complete_script " \"%s\"", g.v.file.name);
-			if (execute(target) != 0)
+			if (execute_hook(complete_script, g.v.file.name) != 0)
 				d_log("zipscript-c: Failed to execute complete_script: %s\n", strerror(errno));
 
 #if ( enable_nfo_script == TRUE )
@@ -1758,8 +1751,7 @@ main(int argc, char **argv)
 					d_log("zipscript-c: Warning - nfo_script (%s) - file does not exist!\n", nfo_script);
 				}
 				d_log("zipscript-c: Executing nfo script (%s)\n", nfo_script);
-				sprintf(target, nfo_script " \"%s\"", g.v.file.name);
-				if (execute(target) != 0)
+				if (execute_hook(nfo_script, g.v.file.name) != 0)
 					d_log("zipscript-c: Failed to execute nfo_script: %s\n", strerror(errno));
 			}
 #endif
@@ -1836,8 +1828,7 @@ main(int argc, char **argv)
 			d_log("zipscript-c: Warning - accept_script (%s) - file does not exist!\n", accept_script);
 		}
 		d_log("zipscript-c: Executing accept script\n");
-		sprintf(target, accept_script " \"%s\"", g.v.file.name);
-		if (execute(target) != 0)
+		if (execute_hook(accept_script, g.v.file.name) != 0)
 			d_log("zipscript-c: Failed to execute accept_script: %s\n", strerror(errno));
 
 #if ( enable_nfo_script == TRUE )
@@ -1846,8 +1837,7 @@ main(int argc, char **argv)
 				d_log("zipscript-c: Warning - nfo_script (%s) - file does not exist!\n", nfo_script);
 			}
 			d_log("zipscript-c: Executing nfo script (%s)\n", nfo_script);
-			sprintf(target, nfo_script " \"%s\"", g.v.file.name);
-			if (execute(target) != 0)
+			if (execute_hook(nfo_script, g.v.file.name) != 0)
 				d_log("zipscript-c: Failed to execute nfo_script: %s\n", strerror(errno));
 		}
 #endif
@@ -1870,8 +1860,7 @@ main(int argc, char **argv)
 			d_log("zipscript-c: Warning - affil_script (%s) - file does not exist!\n", affil_script);
 		}
 		d_log("zipscript-c: Executing affil script\n");
-		sprintf(target, affil_script " \"%s\"", g.v.file.name);
-		if (execute(target) != 0)
+		if (execute_hook(affil_script, g.v.file.name) != 0)
 			d_log("zipscript-c: Failed to execute affil_script: %s\n", strerror(errno));
 	}
 #endif
@@ -1882,8 +1871,7 @@ main(int argc, char **argv)
 			if (!fileexists(delbanned_script))
 				d_log("zipscript-c: Warning - delbanned script (%s) does not exist.\n", delbanned_script);
 
-			sprintf(target, delbanned_script " \"%s\"", g.l.path);
-			if (execute(target) == 0)
+			if (execute_hook(delbanned_script, g.l.path) == 0)
 				d_log("zipscript-c: marking deleted of %s successful.\n", g.l.path);
 			else {
 				d_log("zipscript-c: marking deleted of %s failed.\n", g.l.path);

--- a/zipscript/src/zsfunctions.c
+++ b/zipscript/src/zsfunctions.c
@@ -728,15 +728,10 @@ removecomplete(int rtype)
 	struct dirent	*dp;
 
         struct stat     fileinfo;
-        char            deref_link[PATH_MAX];
-        ssize_t         len;
 
         if (message_file_name != DISABLED && message_file_name && lstat(message_file_name, &fileinfo) != -1) {
-                if (S_ISLNK(fileinfo.st_mode) && stat(message_file_name, &fileinfo) != -1 && (len = readlink(message_file_name, deref_link, sizeof(deref_link)-1)) != -1) {
-                        d_log("removecomplete: message_file_name is a symlink: %s points to %s\n", message_file_name, deref_link);
-                        deref_link[len] = '\0';
-                        unlink(deref_link);
-                }
+                if (S_ISLNK(fileinfo.st_mode))
+                        d_log("removecomplete: message_file_name is a symlink; removing only the symlink (%s)\n", message_file_name);
                 unlink(message_file_name);
         }
 

--- a/zipscript/src/zsfunctions.c
+++ b/zipscript/src/zsfunctions.c
@@ -1238,6 +1238,43 @@ execute_argv(char *const argv[])
 	return status;
 }
 
+/* Execute a configured hook script with a single untrusted argument */
+int
+execute_hook(char *script, char *arg)
+{
+	char	*argv[4];
+	char	argbuf[PATH_MAX * 2];
+
+	if (!script || !arg)
+		return -1;
+	argv[0] = script;
+	snprintf(argbuf, sizeof(argbuf), "%s", arg);
+	argv[1] = argbuf;
+	argv[2] = NULL;
+	return execute_argv(argv);
+}
+
+/* Execute a configured hook script with whitespace-separated cookie args */
+int
+execute_cookies(char *script, char *argline)
+{
+	char	*argv[64];
+	char	buf[PATH_MAX * 2];
+	char	*p;
+	int	argc = 0;
+
+	if (!script)
+		return -1;
+	argv[argc++] = script;
+	if (argline) {
+		snprintf(buf, sizeof(buf), "%s", argline);
+		for (p = strtok(buf, " \t"); p && argc < 63; p = strtok(NULL, " \t"))
+			argv[argc++] = p;
+	}
+	argv[argc] = NULL;
+	return execute_argv(argv);
+}
+
 #ifdef USING_GLFTPD
 /* Only under glftpd do we have a uid/gid-lookup, so these
  * are only needed there. */

--- a/zipscript/src/zsfunctions.c
+++ b/zipscript/src/zsfunctions.c
@@ -1030,6 +1030,22 @@ fileexists(char *f)
  * Last modified by: psxc
  *         Revision: r1228
  */
+
+static int safe_sort_name(const char *s)
+{
+	const char *p;
+
+	if (!s || !*s)
+		return 0;
+	for (p = s; *p; p++) {
+		if ((unsigned char)*p < 32 || *p == '/')
+			return 0;
+	}
+	if (s[0] == '.' && (s[1] == '\0' || (s[1] == '.' && s[2] == '\0')))
+		return 0;
+	return 1;
+}
+
 void 
 createlink(char *factor1, char *factor2, char *source, char *ltarget)
 {
@@ -1044,6 +1060,11 @@ createlink(char *factor1, char *factor2, char *source, char *ltarget)
 
 	if (factor1 == NULL || factor2 == NULL || source == NULL || ltarget == NULL) {
 		d_log("zsfunctions.c: createlink() - received a null value as one of the arguments: (%s, %s, %s, %s)\n", factor1, factor2, source, ltarget);
+		return;
+	}
+
+	if (!safe_sort_name(factor2) || !safe_sort_name(ltarget)) {
+		d_log("createlink: refusing unsafe sort factor (%s, %s)\n", factor2, ltarget);
 		return;
 	}
 


### PR DESCRIPTION
- F-011 removecomplete(): avoid dereferencing symlink targets when removing completed release markers; use lstat() and remove the link itself.
- F-010 racestats: validate and sandbox the path argument before use.
- F-004 ng-chown: enforce allowed-path and symlink checks before chown.
- F-013 audiosort: sanitize sort-factor values before path construction.
- F-009 zipscript hooks: invoke configured hooks via argv instead of a shell to remove command injection.
- F-012 psxc-trailer: add http/https URL validation, switch Apple quickfind to HTTPS, quote wget arguments, and default validdirs to empty so the script does not run everywhere by default.
