### PR TITLE
psxc-imdb v3.2: shared library, localized URLs, FreeBSD support, GLROOT from conf only

### DIFF
--- a/scripts/psxc-imdb/CHANGELOG
+++ b/scripts/psxc-imdb/CHANGELOG
@@ -1,5 +1,55 @@
 PSXC-IMDB CHANGELOG:
 --------------------
+- v3.2 - Aug. 21st, 2026 - Create psxc-imdb-lib.sh shared library to eliminate
+                           code duplication across the suite
+                           - Functions: imdb_set_defaults(), imdb_load_config(),
+                              imdb_write_log(), imdb_queue_lookup(),
+                              imdb_request(), imdb_extract_id()
+                           - Move COUNTRY_MAP and LANGUAGE_MAP to lib
+                           - Replace inline config loading, logging, and queue
+                             writes with lib function calls
+                           - Fix lib sourcing path for glftpd chroot: use
+                             $(dirname $0) instead of $GLROOT/bin
+                           - Unify VERSION to 3.2 across all scripts
+                           - Move infra defaults into imdb_set_defaults()
+                           - Remove obsolete LOCALURL/IMDBLOCAL (IMDB retired
+                             country-specific subdomains like german.imdb.com)
+                           - Re-introduce LOCALURL option with path-based
+                             localized URLs (e.g. LOCALURL="de" ->
+                             www.imdb.com/de/title/tt...). IMDB now serves
+                             localized content via URL path segments instead.
+                             Supported: de, fr, es, it, pt, hi
+                           - Add FIXDIRTIME option (default: empty ""). When set
+                              to "YES", the release dir's original mtime is
+                              snapshotted before the info files are written and
+                              restored afterwards via touch -r (POSIX) to a temp
+                              carrier in the logs dir, keeping the dir date
+                              unchanged (upload-order dirlists stay intact) and
+                              covering both the success and the API-error paths.
+                              With the default "", the script never actively
+                              touches directory timestamps
+                           - Installer detects required binaries (bash 4+, jq,
+                              curl) across /usr/local/bin and standard paths, with
+                              per-OS install hints and portable sed/tr config
+                              generation (Linux + FreeBSD)
+                           - POSIX-compatible tools throughout (no GNU-only
+                              grep -oP/-a, echo -e, rmdir flags, ls date sorting);
+                              BSD stat -f date handling via get_file_date()
+                           - Addons (nuker, symlink-maker) auto-detect their
+                              config paths in direct and rescan-context
+                              invocations; only files needing edits are prompted
+                              for during install
+                           - psxc-symlink-maker.sh creates relative symlink
+                              targets
+                           - Missing rescan flag file handled gracefully instead
+                              of erroring
+                           - Queue processing: per-release flags (DOTIMDB, USEBOT,
+                              EXTERNALSCRIPTNAME, INFOTEMPNAME, bot and log-format
+                              vars) are snapshotted after run-level flag handling
+                              and restored at the top of each queue iteration, so
+                              an API error, a removed release dir, or a find
+                              /dev/null entry no longer leaks cleared state into
+                              the next release processed in the same run
 - v3.1 - Jul. 24th, 2026 - Switch psxc-imdb to IMDB GraphQL API (graphql.imdb.com)
                           - Add Metacritic score (metascore + review count) to
                             bot output, .imdb file, and external script args

--- a/scripts/psxc-imdb/FILES
+++ b/scripts/psxc-imdb/FILES
@@ -9,9 +9,11 @@ TODO                     - Your requests, future plans.
 UPGRADING                - What needs to be done to upgrade your install.
 main/
  - psxc-imdb.sh          - Main script. (chmod 755)
- - psxc-imdb-bot.tcl     - botscript. (chmod 644)
+ - psxc-imdb-lib.sh      - Shared API library. (chmod 644)
  - psxc-imdb.conf        - main configfile. (chmod 644)
- - psxc-imdb-conf.tcl    - tcl configfile. (chmod 644)
+ - psxc-imdb.tcl         - botscript. (chmod 644)
+ - psxc-imdb.zpt         - botscript theme file. (chmod 644)
+ - old/                  - Old bot/config tcl files, kept for reference.
 addons/                  - Directory with addons, aka EXTERNALSCRIPT.
  - psxc-imdb-nuker.sh    - An auto nuker/logger/nuke warner.
  - psxc-symlink-maker.sh - A symlink maker used to sort releases based on
@@ -24,8 +26,11 @@ extras/                  - Directory with example-files and other helpful things
                             addons.
  - psxc-imdb-find.sh     - A script used to find imdb-info based on name.
                             Mostly used in conjunction with psxc-imdb-find.tcl.
+installer.sh             - The installer script. (chmod 755)
 other/                   - Directory with other stuff for the imdb-script.
-diff/                    - Directory with diff-files. Useful for patching
-                            your own modified files, or checking what's
-                            changed.
+ - libcopy.sh            - Copies needed libs to your chroot.
+ - makeclean.sh          - Removes empty lines and comments from a configfile.
+ - makediff.sh           - Makes a diff-file of your modified files.
+ - stripcr.sh            - Strips CR from files.
+ - psxc-depcheck_v0.1.tgz - A dependency checker.
 

--- a/scripts/psxc-imdb/README
+++ b/scripts/psxc-imdb/README
@@ -71,8 +71,11 @@ channel output. In it's basic form, it's a single, small(?) file.
 - It supports output of imdb info into a file inside the releasedir, making it
   possible to auto-view on entering the dir.
 - It can generate an Internet Explorer .url or .html, for easy click-n-view.
-- Supports links to international ( German, Italian, French and others)
-  versions of imdb.com - will show the US data however.
+- Supports localized IMDB links via LOCALURL. Set LOCALURL in psxc-imdb.conf
+  to a language code to display IMDB URLs with a localized path segment
+  (e.g. LOCALURL="de" -> www.imdb.com/de/title/tt...).
+  Supported languages: de (German), fr (French), es (Spanish),
+  it (Italian), pt (Portuguese/Brazil), hi (Hindi).
 - Very stable - will extract a valid imdb link from almost any .nfo (unlike
   others I've seen)
 - Support for addons - three example addons is currently included. One which create
@@ -423,6 +426,24 @@ ADDING YOUR OWN FORMATTED BOT-OUTPUT (OPTIONAL):
    set up the internal formatting, and the external formatting can be explored
    in the file "README.use.of.special.format".
 
+USING LOCALIZED IMDB URLS (OPTIONAL):
+.....................................
+   To display IMDB links in a localized format, set LOCALURL in psxc-imdb.conf
+   to one of the supported language codes. This changes the displayed URL from
+   https://www.imdb.com/title/tt0111161 to https://www.imdb.com/<code>/title/tt0111161.
+
+   Supported language codes:
+     de - German
+     fr - French
+     es - Spanish
+     it - Italian
+     pt - Portuguese (Brazil)
+     hi - Hindi
+
+   This affects bot output, .imdb files, .url/.html redirects, and
+   psxc-imdb-find.sh results. Leave LOCALURL="" (default) for standard
+   English URLs.
+
 USING THE "FULL" FEATURE (OPTIONAL):
 ....................................
    At times your default botscript cannot handle the imdb output. Or you might decide
@@ -465,6 +486,11 @@ EXTRAS:
 In the extras folder you'll find a few goodies you probably would like to use.
 psxc-imdb-rescan.sh - this is a site script used to rescan a dir, or a whole
                       section.
+                      By default the script does not touch directory timestamps
+                      (FIXDIRTIME=""). Set FIXDIRTIME="YES" in psxc-imdb.conf
+                      to restore the release dir's original mtime after the imdb
+                      info is written (snapshot taken before the run), keeping
+                      upload-order dirlists intact.
 psxc-imdb-sanity.sh - you have probably used this already - it sets up and
                       verifies your environment and settings.
 psxc-imdb-parser.sh - not a real script - it just shows how you can grab the

--- a/scripts/psxc-imdb/UPGRADING
+++ b/scripts/psxc-imdb/UPGRADING
@@ -1,10 +1,34 @@
 PSXC-IMDB UPGRADING:
 --------------------
 
-NOTE: If you use a different GLROOT than /glftpd, you most
-      likely need to change a couple of variables in the files
-      you replace.
+NOTE: If you use a different GLROOT than /glftpd, set GLROOT in
+      psxc-imdb.conf and the paths in psxc-imdb.tcl accordingly.
+      psxc-imdb-find.sh and the addons auto-detect their config.
 
+3.1 -> 3.2 - replace psxc-imdb.sh, psxc-imdb-lib.sh, psxc-imdb.conf, psxc-imdb.tcl,
+             installer.sh
+             - if you use them, also replace:
+             - psxc-imdb-rescan.sh, psxc-imdb-find.sh, psxc-imdb-sanity.sh,
+               psxc-imdb-parser.sh
+             - psxc-imdb-nuker.sh, psxc-symlink-maker.sh, psxc-imdb-dotimdb.pl
+             --- new variables:
+             - psxc-imdb.conf: FIXDIRTIME (default: "" - empty means never
+               actively touch dir timestamps; set to "YES" to restore the
+               release dir's original mtime after writing the info files)
+             - psxc-imdb.conf: LOCALURL (set to a language code for localized
+               IMDB URLs, e.g. "de". Leave empty for default English URLs.
+               Supported: de, fr, es, it, pt, hi)
+             NOTE: psxc-imdb-lib.sh is REQUIRED. If missing, psxc-imdb.sh
+                   exits silently and does nothing.
+3.0 -> 3.1 - replace psxc-imdb.sh, psxc-imdb.conf, psxc-imdb.tcl, installer.sh
+             - if you use them, also replace:
+             - psxc-imdb-find.sh, psxc-imdb-sanity.sh
+             - psxc-imdb-nuker.sh, psxc-symlink-maker.sh
+             --- new variables:
+             - psxc-imdb.conf: IMDB_GRAPHQL_URL
+             - psxc-imdb.conf: SHOWMETACRITIC
+             - psxc-imdb.conf: USEORIGTITLE
+             - psxc-imdb.conf: USERAGENT
 2.9v -> 2.9w - replace psxc-imdb.sh, psxc-imdb-rescan.sh
 2.9u -> 2.9v - replace psxc-imdb.sh, psxc-imdb-find.sh, psxc-imdb-rescan.sh
              --- new variables:

--- a/scripts/psxc-imdb/addons/psxc-imdb-dotimdb.pl
+++ b/scripts/psxc-imdb/addons/psxc-imdb-dotimdb.pl
@@ -61,7 +61,7 @@ format DOTONE =
   $IMDBURL
 |--------------------------------------------------------------------------|
 | genre...: ^<<<<<<<<<<<<<<<<<<<<<<<<<<... | ^<<<<<<<<<<<<<<<<<<<<<<<<<<<< |
-            $IMDBGENRE                       $IMDBPLOT
+            $IMDBGENRE,                      $IMDBPLOT
 | score...: [@<<<<<<<<<]  @<< @>>>>> votes | ^<<<<<<<<<<<<<<<<<<<<<<<<<<<< |
             $IMDBBAR,    $IMDBSCORE, $IMDBVOTES, $IMDBPLOT
 | director: ^<<<<<<<<<<<<<<<<<<<<<<<<<<... | ^<<<<<<<<<<<<<<<<<<<<<<<<<<<< |
@@ -278,7 +278,7 @@ sub limit {
  $IMDBVOTES, $IMDBSCORE, $IMDBNAME, $IMDBYEAR, $IMDBNUMSCREENS,
  $IMDBISLIMITED, $IMDBCASTLEADNAME, $IMDBCASTLEADCHAR, $IMDBTAGLINE,
  $IMDBPLOT, $IMDBBAR, $IMDBCASTING, $IMDBCOMMENTSHORT, 
- $IMDBCOMMENTLONG) = @imdbvars;
+ $IMDBCOMMENTLONG, $IMDBMETACRITIC) = @imdbvars;
 
 # limit stuff
 $IMDBGENRE = limit($IMDBGENRE, $NUMGENRE, "/");

--- a/scripts/psxc-imdb/addons/psxc-imdb-nuker.sh
+++ b/scripts/psxc-imdb/addons/psxc-imdb-nuker.sh
@@ -16,14 +16,7 @@
 #############################################################################
 
 # Version number. No need to change
-VERSION=3.1
-
-# glftpd's root dir
-GLROOT=/glftpd
-
-# The location of psxc-imdb.conf. This is the full path.
-IMDB_CONF=$GLROOT/etc/psxc-imdb.conf
-#IMDB_CONF=$GLROOT/bin/psxc-imdb.conf
+VERSION=3.2
 
 # What imdb score should be the minimum *allowed* on site? For now no decimals
 # is allowed.
@@ -114,9 +107,18 @@ NO_NUKE_RELGROUP="CPY QSP"
 NO_NUKE_DIR="/site/ARCHIVE /site/PRIVATE"
 #NO_NUKE_DIR=""
 
-# The location of glftpd.conf. This is the full path.
-GLFTPD_CONF=/glftpd/etc/glftpd.conf
-#GLFTPD_CONF=/etc/glftpd.conf
+# Source shared library and load psxc-imdb.conf (GLROOT's single source
+# of truth, provided before the GLROOT-dependent defaults below).
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$SCRIPT_DIR/psxc-imdb-lib.sh"
+imdb_set_defaults
+imdb_load_config || exit 1
+
+# The location of glftpd.conf. Auto-detected (works chrooted and on the host).
+for c in "$GLROOT/etc/glftpd.conf" "/etc/glftpd.conf"; do
+ [ -r "$c" ] && GLFTPD_CONF="$c" && break
+done
+: ${GLFTPD_CONF:=$GLROOT/etc/glftpd.conf}
 
 # Since nuking require root privileges, or that the nuker binary has the set-UID-bit
 # set (chmod +s /glftpd/bin/nuker), You can instead of performing the nuke in this
@@ -188,56 +190,10 @@ CRON_GRACE=600
 # End of config
 ####################################################################################
 
-# Let's load some variables from psxc-imdb.conf
-. $IMDB_CONF
+# The following grabs exported variables using the shared parse_imdb_args function
+# from psxc-imdb-lib.sh.
 
-####################################################################################
-# The following grabs exported variables. The code is taken from psxc-imdb-parser.sh
-# found in the extras/ dir.
-
-IFSORIG=$IFS
-IFS="^"
-
-# Initialize variables. bash is a bit limited, so we gotta do a "hack"
-c=1
-for a in `echo $@ | sed "s/^\"//;s/\"$//;s|\" \"|^|g"`; do
-b[c]=$a
-let c=c+1
-done
-
-IFS=$IFSORIG
-
-# Give the variables some sensible names
-IMDBDATE=${b[1]}
-IMDBDOTFILE=${b[2]}
-IMDBRELPATH=${b[3]}
-IMDBDIRNAME=${b[4]}
-IMDBURL=${b[5]}
-IMDBTITLE=${b[6]}
-IMDBGENRE=${b[7]}
-IMDBRATING=${b[8]}
-IMDBCOUNTRY=${b[9]}
-IMDBLANGUAGE=${b[10]}
-IMDBCERTIFICATION=${b[11]}
-IMDBRUNTIME=${b[12]}
-IMDBDIRECTOR=${b[13]}
-IMDBBUSINESSDATA=${b[14]}
-IMDBPREMIERE=${b[15]}
-IMDBLIMITED=${b[16]}
-IMDBVOTES=${b[17]}
-IMDBSCORE=${b[18]}
-IMDBNAME=${b[19]}
-IMDBYEAR=${b[20]}
-IMDBNUMSCREENS=${b[21]}
-IMDBISLIMITED=${b[22]}
-IMDBCASTLEADNAME=${b[23]}
-IMDBCASTLEADCHAR=${b[24]}
-IMDBTAGLINE=${b[25]}
-IMDBPLOT=${b[26]}
-IMDBBAR=${b[27]}
-IMDBCASTING=${b[28]}
-IMDBCOMMENTSHORT=${b[29]}
-IMDBCOMMENTFULL=${b[30]}
+parse_imdb_args "$@"
 
 ############################################################
 
@@ -249,25 +205,25 @@ if [ -z "$GLFTPD_CONF" ]; then
  exit 0
 fi
 if [ -z "$NUKE_LOGFILE" ] && [ -z "$NUKE_WARN_MSG" ]; then
- if [ -z "`ls -la $GLROOT/bin/nuker | grep "-" | awk '{print $1}' | tr -d 'rwx-'`" ]; then
+ if [ -z "`ls -la "$GLROOT/bin/nuker" | grep "-" | awk '{print $1}' | tr -d 'rwx-'`" ]; then
   echo "config error. check variables. the 'nuker' binary is not +s."
   exit 0
  fi
- if [ ! `ls -lan $GLROOT/bin/nuker | awk '{print $3}'` -eq 0 ]; then
+ if [ ! "`ls -lan "$GLROOT/bin/nuker" | awk '{print $3}'`" -eq 0 ]; then
   echo "config error. the 'nuker' binary is not owned by root."
   exit 0
  fi
- GL_DATAPATH="`cat $GLFTPD_CONF | grep -e "^datapath" | awk '{print $2}'`"
+ GL_DATAPATH="`cat "$GLFTPD_CONF" | grep -e "^datapath" | awk '{print $2}'`"
  if [ -z "$GL_DATAPATH" ]; then
   GL_DATAPATH="/ftp-data"
  fi
- if [ ! -e $GLROOT$GL_DATAPATH/users/$NUKER_PERSON ]; then
+ if [ ! -e "$GLROOT$GL_DATAPATH/users/$NUKER_PERSON" ]; then
   echo "config error. check variables. could not find $NUKER_PERSON in list of users."
   exit 0
  fi
 fi
 if [ ! -z "$NUKE_LOGFILE" ]; then
- if [ ! -e $NUKE_LOGFILE ]; then
+ if [ ! -e "$NUKE_LOGFILE" ]; then
   touch $NUKE_LOGFILE || { 
    echo "config error. could not create $NUKE_LOGFILE."; exit 0;
   };
@@ -295,7 +251,7 @@ if [ -z "$IMDBRELPATH" ]; then
  echo "FYI, the script's setup looks okay."
  echo "To use a delayed nuke, see NUKE_GRACE and add the"
  echo "following to crontab:"
- echo "* * * * * /glftpd/bin/psxc-imdb-nuker.sh >/dev/null 2>&1"
+ echo "* * * * * $GLROOT/bin/psxc-imdb-nuker.sh >/dev/null 2>&1"
  let COMBO=NUKE_COMBO+1
 else
 
@@ -340,23 +296,23 @@ else
 # Let's do a quick test to see if the release should be nuked
  NUKE_REASON=""
  if [ "`echo "$IMDBSCORE" | tr -cd '0-9'`" != "" ]; then
-  if [ `echo "$IMDBSCORE" | tr '. ' '\n' | grep -v "^$" | head -n 1` -lt $MIN_SCORE ]; then
+  if [ "`echo "$IMDBSCORE" | tr '. ' '\n' | grep -v "^$" | head -n 1`" -lt "$MIN_SCORE" ]; then
    NUKE_REASON="$MIN_SCORE_MSG"
    let COMBO=COMBO+1
   fi
  fi
  if [ "`echo "$IMDBVOTES" | tr -cd '0-9'`" != "" ]; then
-  if [ `echo "$IMDBVOTES" | tr -cd '0-9'` -lt $NUKE_VOTES ]; then
+  if [ "`echo "$IMDBVOTES" | tr -cd '0-9'`" -lt "$NUKE_VOTES" ]; then
    NUKE_REASON="$NUKE_VOTES_MSG"
    let COMBO=COMBO+1
   fi
  fi
- if [ `echo "$IMDBYEAR" | tr -cd '0-9'` -lt $NUKE_YEAR ]; then
+ if [ "`echo "$IMDBYEAR" | tr -cd '0-9'`" -lt "$NUKE_YEAR" ]; then
   NUKE_REASON="$NUKE_YEAR_MSG"
   let COMBO=COMBO+1
  fi
  if [ "`echo "$IMDBNUMSCREENS" | tr -cd '0-9'`" != "" ]; then
-  if [ `echo "$IMDBNUMSCREENS" | tr -cd '0-9'` -lt $NUKE_SCREENS ]; then
+  if [ "`echo "$IMDBNUMSCREENS" | tr -cd '0-9'`" -lt "$NUKE_SCREENS" ]; then
    NUKE_REASON="$NUKE_SCREENS_MSG"
    let COMBO=COMBO+1
   fi
@@ -412,8 +368,8 @@ else
 
  if [ ! -z "$NO_NUKE_USER" ]; then
   USER_ID=`ls -lan "$GLROOT/$IMDBRELPATH" | grep -e "\ \.$" | awk '{print $3}'`
-  USER_NAME="`cat $GLROOT/etc/passwd | tr -d ' ' | tr ':' ' ' | awk '{print $1,$3}' | grep -e "\ $USER_ID$" | awk '{print $1}'`"
-  if [ ! -z "`echo "$NO_NUKE_USER" | grep $USER_NAME`" ]; then
+  USER_NAME="`cat "$GLROOT/etc/passwd" | tr -d ' ' | tr ':' ' ' | awk '{print $1,$3}' | grep -e "\ $USER_ID$" | awk '{print $1}'`"
+  if [ ! -z "`echo "$NO_NUKE_USER" | grep "$USER_NAME"`" ]; then
    exit 0
   fi
  fi
@@ -422,8 +378,8 @@ else
 
  if [ ! -z "$NO_NUKE_GROUP" ]; then
   GROUP_ID=`ls -lan "$GLROOT/$IMDBRELPATH" | grep -e "\ \.$" | awk '{print $4}'`
-  GROUP_NAME="`cat $GLROOT/etc/group | tr -d ' ' | sed "s|::|:vomit:|g" | tr ':' ' ' | awk '{print $1,$3}' | grep -e "\ $GROUP_ID$" | awk '{print $1}'`"
-  if [ ! -z "`echo "$NO_NUKE_GROUP" | grep $GROUP_NAME`" ]; then
+  GROUP_NAME="`cat "$GLROOT/etc/group" | tr -d ' ' | sed "s|::|:vomit:|g" | tr ':' ' ' | awk '{print $1,$3}' | grep -e "\ $GROUP_ID$" | awk '{print $1}'`"
+  if [ ! -z "`echo "$NO_NUKE_GROUP" | grep "$GROUP_NAME"`" ]; then
    exit 0
   fi
  fi
@@ -432,10 +388,10 @@ else
 
  if [ ! -z "$NO_NUKE_AFFIL_DIR" ]; then
   AFFIL_ID=`ls -lan "$GLROOT/$IMDBRELPATH" | grep -e "\ \.$" | awk '{print $4}'`
-  AFFIL_NAME="`cat $GLROOT/etc/group | tr -d ' ' | sed "s|::|:vomit:|g" | tr ':' ' ' | awk '{print $1,$3}' | grep -e "\ $AFFIL_ID$" | awk '{print $1}'`"
+  AFFIL_NAME="`cat "$GLROOT/etc/group" | tr -d ' ' | sed "s|::|:vomit:|g" | tr ':' ' ' | awk '{print $1,$3}' | grep -e "\ $AFFIL_ID$" | awk '{print $1}'`"
   for AFFIL_DIR in $NO_NUKE_AFFIL_DIR; do
-   if [ -d $GLROOT/$AFFIL_DIR ]; then
-    if [ ! -z "`ls -lF $GLROOT/$AFFIL_DIR | grep -e "/" | grep -e "\ $AFFIL_NAME/"`" ]; then
+   if [ -d "$GLROOT/$AFFIL_DIR" ]; then
+    if [ ! -z "`ls -lF "$GLROOT/$AFFIL_DIR" | grep -e "/" | grep -e "\ $AFFIL_NAME/"`" ]; then
      exit 0
     fi
    fi
@@ -524,7 +480,7 @@ fi
 
 # last, let's check the dir for any approved info
 if [ ! -z "$REL_ACCEPT_WORD" ]; then
- MYPATH="`ls -1 $GLROOT$IMDBRELPATH | tr 'A-Z' 'a-z'`"
+ MYPATH="`ls -1 "$GLROOT$IMDBRELPATH" | tr 'A-Z' 'a-z'`"
  MYWORD="`echo "$REL_ACCEPT_WORD" | tr 'A-Z' 'a-z'`"
  if [ ! -z "`echo "$MYPATH" | grep -e "$MYWORD"`" ]; then
   exit 0
@@ -532,7 +488,7 @@ if [ ! -z "$REL_ACCEPT_WORD" ]; then
 fi
 
 # Check combo-points
-if [ $NUKE_COMBO -gt $COMBO ]; then
+if [ "$NUKE_COMBO" -gt "$COMBO" ]; then
  exit 0
 fi
 
@@ -540,10 +496,10 @@ fi
 # nuke it, or log it.
 
 if [ -z "$NUKE_WARN_FILE" ] && [ -z "$NUKE_LOGFILE" ]; then
- $GLROOT/bin/nuker -r $GLFTPD_CONF -N $NUKER_PERSON -n "$IMDBRELPATH/" $MULTIPLIER $NUKE_REASON >/dev/null 2>&1
+ "$GLROOT/bin/nuker" -r "$GLFTPD_CONF" -N "$NUKER_PERSON" -n "$IMDBRELPATH/" "$MULTIPLIER" "$NUKE_REASON" >/dev/null 2>&1
 else
  if [ ! -z "$NUKE_LOGFILE" ]; then
-  echo "`date +%s`""%""$IMDBRELPATH""%""$MULTIPLIER""%""$NUKE_REASON" >> $NUKE_LOGFILE
+  echo "`date +%s`""%""$IMDBRELPATH""%""$MULTIPLIER""%""$NUKE_REASON" >> "$NUKE_LOGFILE"
  fi
  if [ ! -z "$NUKE_WARN_FILE" ]; then
   NUKE_WARN_MSG="`echo "$NUKE_WARN_MSG" | sed "s%RELNAME%$IMDBDIRNAME%g" | sed "s%REASON%$NUKE_REASON%g" | sed "s%MOVIENAME%$IMDBNAME%g" | sed "s%BOLD%$BOLD%g"`" 

--- a/scripts/psxc-imdb/addons/psxc-symlink-maker.sh
+++ b/scripts/psxc-imdb/addons/psxc-symlink-maker.sh
@@ -18,10 +18,7 @@ LANG="C.utf8"
 ############################################################################
 
 # version number. no need to change
-VERSION=3.1
-
-# The location of psxc-imdb.conf. This is the full path.
-IMDB_CONF=/glftpd/etc/psxc-imdb.conf
+VERSION=3.2
 
 # Where should symlinks be put? This is relative to $GLROOT.
 SYMLINK_PATH=/site/MOVIES_SORTED
@@ -148,54 +145,29 @@ CLEANUP_SYMLINKS=0
 # If you put the above variables in psxc-imdb.conf, they will override what is
 # put in this file. Should be helpful if you want all variables to be in one
 # place.
-. $IMDB_CONF
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$SCRIPT_DIR/psxc-imdb-lib.sh"
+imdb_set_defaults
+imdb_load_config || exit 1
 
-# The following is the routine to grab variables from psxc-imdb. It's a copy
-# of the code in psxc-imdb-parser.sh in the /extras dir.
+# The following is the routine to grab variables from psxc-imdb. It uses
+# the shared parse_imdb_args function from psxc-imdb-lib.sh.
 
-IFSORIG=$IFS
-IFS="^"
+parse_imdb_args "$@"
 
-# Initialize variables. bash is a bit limited, so we gotta do a "hack"
-c=1
-for a in `echo $@ | sed "s/^\"//;s/\"$//;s|\" \"|^|g"`; do
-b[c]=$a
-let c=c+1
-done
-
-IFS=$IFSORIG
-
-# Give the variables some sensible names
-IMDBDATE=${b[1]}
-IMDBDOTFILE=${b[2]}
-IMDBRELPATH=${b[3]}
-IMDBDIRNAME=${b[4]}
-IMDBURL=${b[5]}
-IMDBTITLE=${b[6]}
-IMDBGENRE=${b[7]}
-IMDBRATING=${b[8]}
-IMDBCOUNTRY=${b[9]}
-IMDBLANGUAGE=${b[10]}
-IMDBCERTIFICATION=${b[11]}
-IMDBRUNTIME=${b[12]}
-IMDBDIRECTOR=${b[13]}
-IMDBBUSINESSDATA=${b[14]}
-IMDBPREMIERE=${b[15]}
-IMDBLIMITED=${b[16]}
-IMDBVOTES=${b[17]}
-IMDBSCORE=${b[18]}
-IMDBNAME=${b[19]}
-IMDBYEAR=${b[20]}
-IMDBNUMSCREENS=${b[21]}
-IMDBISLIMITED=${b[22]}
-IMDBCASTLEADNAME=${b[23]}
-IMDBCASTLEADCHAR=${b[24]}
-IMDBTAGLINE=${b[25]}
-IMDBPLOT=${b[26]}
-IMDBBAR=${b[27]}
-IMDBCASTING=${b[28]}
-IMDBCOMMENTSHORT=${b[29]}
-IMDBCOMMENTFULL=${b[30]}
+# Build a relative symlink target. $1 = number of subdir levels under
+# $SYMLINK_PATH. FTP clients never see /site, so climb up past the site root
+# (N+1 levels) then descend into the release path with the leading /site/
+# stripped. e.g. a Genre link at /site/MOVIES_SORTED/Sorted.by.Genre/Drama/
+# to /site/movies-hd/abhahaha stores ../../../movies-hd/abhahaha.
+relative_target() {
+ local levels="$1" up="" i=0
+ while [ $i -le "$levels" ]; do
+  up="$up../"
+  i=$((i+1))
+ done
+ echo "$up${IMDBRELPATH#/site/}"
+}
 
 ###### Let's start
 
@@ -232,7 +204,7 @@ if [ -z "$IMDBRELPATH" ]; then
  echo "You can take advantage of this if you like, by adding a crontab entry"
  echo "and setting CLEANUP_SYMLINKS=0. The addon will be faster..."
  echo "A crontab entry can look like this (running every 30 mins):"
- echo "7,37 * * * * /glftpd/bin/psxc-symlink-maker.sh >/dev/null 2>&1"
+ echo "7,37 * * * * $GLROOT/bin/psxc-symlink-maker.sh >/dev/null 2>&1"
  echo ""
  echo "Please wait while I check for dead links..."
  echo ""
@@ -262,7 +234,8 @@ proc_cleanup() {
  for LINK in `ls -AF "$1" | tr ' ' '%'`; do
   LINK="`echo "$LINK" | sed "s/@$//" | tr '%' ' '`"
   LINK_DST="$(readlink "$1/$LINK")"
-  [[ ! -e "$GLROOT$LINK_DST" ]] &&
+  # Targets are relative now; resolve from the sorted dir (host path).
+  ( cd "$1" && [ ! -e "$LINK_DST" ] ) &&
    rm -f "$1`basename "$LINK"`"
  done
 }
@@ -274,7 +247,7 @@ proc_cleanup_single() {
  for SDIR in `ls -AF "$1" | tr ' ' '%' | sed 's|^|.../|'`; do
   SDIR="`echo "$SDIR" | tr '%' ' ' | sed 's|^\.\.\./||'`"
   proc_cleanup "$1/$SDIR"
-  rmdir --ignore-fail-on-non-empty "$1/$SDIR"
+  rmdir "$1/$SDIR" 2>/dev/null
  done
 }
 
@@ -283,7 +256,7 @@ proc_cleanup_double() {
  for DIR in `ls -AF "$1" | tr ' ' '%' | sed 's|^|.../|'`; do
   DIR="`echo "$DIR" | tr '%' ' ' | sed 's|^\.\.\./||'`"
   proc_cleanup_single "$1/$DIR"
-  rmdir --ignore-fail-on-non-empty "$1/$DIR"
+  rmdir "$1/$DIR" 2>/dev/null
  done
 }
 
@@ -307,7 +280,7 @@ if [ $SORT_BY_GENRE -eq 1 ]; then
    [[ ! -d  "$GLROOT$SYMLINK_PATH/$SORT_BY_GENRE_NAME/$GENRE" ]] &&
     mkdir -pm777 "$GLROOT$SYMLINK_PATH/$SORT_BY_GENRE_NAME/$GENRE"
    [[ ! -L "$GLROOT$SYMLINK_PATH/$SORT_BY_GENRE_NAME/$GENRE/$IMDBDIRNAME" ]] &&
-    ln -s "$IMDBRELPATH" "$GLROOT$SYMLINK_PATH/$SORT_BY_GENRE_NAME/$GENRE/$IMDBDIRNAME"
+    ln -s "$(relative_target 2)" "$GLROOT$SYMLINK_PATH/$SORT_BY_GENRE_NAME/$GENRE/$IMDBDIRNAME"
   done
  fi
 fi
@@ -337,7 +310,7 @@ if [ $SORT_BY_LANGUAGE -eq 1 ]; then
    [[ ! -d  "$GLROOT$SYMLINK_PATH/$SORT_BY_LANGUAGE_NAME/$LANGUAGE" ]] &&
     mkdir -pm777 "$GLROOT$SYMLINK_PATH/$SORT_BY_LANGUAGE_NAME/$LANGUAGE"
    [[ ! -L "$GLROOT$SYMLINK_PATH/$SORT_BY_LANGUAGE_NAME/$LANGUAGE/$IMDBDIRNAME" ]] &&
-    ln -s "$IMDBRELPATH" "$GLROOT$SYMLINK_PATH/$SORT_BY_LANGUAGE_NAME/$LANGUAGE/$IMDBDIRNAME"
+    ln -s "$(relative_target 2)" "$GLROOT$SYMLINK_PATH/$SORT_BY_LANGUAGE_NAME/$LANGUAGE/$IMDBDIRNAME"
   done
  fi
 fi
@@ -378,7 +351,7 @@ if [ $SORT_BY_DIRECTOR -eq 1 ]; then
    [[ ! -d "$GLROOT$SYMLINK_PATH/$SORT_BY_DIRECTOR_NAME/$DIRECTORCHAR/$DIRECTOR" ]] &&
     mkdir -pm777 "$GLROOT$SYMLINK_PATH/$SORT_BY_DIRECTOR_NAME/$DIRECTORCHAR/$DIRECTOR"
    [[ ! -L "$GLROOT$SYMLINK_PATH/$SORT_BY_DIRECTOR_NAME/$DIRECTORCHAR/$DIRECTOR/$IMDBDIRNAME" ]] &&
-    ln -s "$IMDBRELPATH" "$GLROOT$SYMLINK_PATH/$SORT_BY_DIRECTOR_NAME/$DIRECTORCHAR/$DIRECTOR/$IMDBDIRNAME"
+    ln -s "$(relative_target 3)" "$GLROOT$SYMLINK_PATH/$SORT_BY_DIRECTOR_NAME/$DIRECTORCHAR/$DIRECTOR/$IMDBDIRNAME"
   done
  fi
 fi
@@ -417,7 +390,7 @@ if [ $SORT_BY_CASTLEADNAME -eq 1 ]; then
   [[ ! -d "$GLROOT$SYMLINK_PATH/$SORT_BY_CASTLEADNAME_NAME/$CASTLEADNAMECHAR/$CASTLEADNAME" ]] &&
    mkdir -pm777 "$GLROOT$SYMLINK_PATH/$SORT_BY_CASTLEADNAME_NAME/$CASTLEADNAMECHAR/$CASTLEADNAME"
   [[ ! -L "$GLROOT$SYMLINK_PATH/$SORT_BY_CASTLEADNAME_NAME/$CASTLEADNAMECHAR/$CASTLEADNAME/$IMDBDIRNAME" ]] &&
-   ln -s "$IMDBRELPATH" "$GLROOT$SYMLINK_PATH/$SORT_BY_CASTLEADNAME_NAME/$CASTLEADNAMECHAR/$CASTLEADNAME/$IMDBDIRNAME"
+   ln -s "$(relative_target 3)" "$GLROOT$SYMLINK_PATH/$SORT_BY_CASTLEADNAME_NAME/$CASTLEADNAMECHAR/$CASTLEADNAME/$IMDBDIRNAME"
  fi
 fi
 
@@ -457,7 +430,7 @@ if [ $SORT_BY_CASTING -eq 1 ]; then
    [[ ! -d "$GLROOT$SYMLINK_PATH/$SORT_BY_CASTING_NAME/$CASTINGCHAR/$CASTING" ]] &&
     mkdir -pm777 "$GLROOT$SYMLINK_PATH/$SORT_BY_CASTING_NAME/$CASTINGCHAR/$CASTING"
    [[ ! -L "$GLROOT$SYMLINK_PATH/$SORT_BY_CASTING_NAME/$CASTINGCHAR/$CASTING/$IMDBDIRNAME" ]] &&
-    ln -s "$IMDBRELPATH" "$GLROOT$SYMLINK_PATH/$SORT_BY_CASTING_NAME/$CASTINGCHAR/$CASTING/$IMDBDIRNAME"
+    ln -s "$(relative_target 3)" "$GLROOT$SYMLINK_PATH/$SORT_BY_CASTING_NAME/$CASTINGCHAR/$CASTING/$IMDBDIRNAME"
   done
  fi
 fi
@@ -480,7 +453,7 @@ if [ $SORT_BY_YEAR -eq 1 ]; then
   [[ ! -d "$GLROOT$SYMLINK_PATH/$SORT_BY_YEAR_NAME/$MYYEAR" ]] &&
    mkdir -pm777 "$GLROOT$SYMLINK_PATH/$SORT_BY_YEAR_NAME/$MYYEAR"
   [[ ! -L "$GLROOT$SYMLINK_PATH/$SORT_BY_YEAR_NAME/$MYYEAR/$IMDBDIRNAME" ]] &&
-   ln -s "$IMDBRELPATH" "$GLROOT$SYMLINK_PATH/$SORT_BY_YEAR_NAME/$MYYEAR/$IMDBDIRNAME"
+   ln -s "$(relative_target 2)" "$GLROOT$SYMLINK_PATH/$SORT_BY_YEAR_NAME/$MYYEAR/$IMDBDIRNAME"
  fi
 fi
 
@@ -503,7 +476,7 @@ if [ $SORT_BY_SCORE -eq 1 ]; then
   [[ ! -d "$GLROOT$SYMLINK_PATH/$SORT_BY_SCORE_NAME/$SCORE" ]] &&
    mkdir -pm777 "$GLROOT$SYMLINK_PATH/$SORT_BY_SCORE_NAME/$SCORE"
   [[ ! -L "$GLROOT$SYMLINK_PATH/$SORT_BY_SCORE_NAME/$SCORE/$IMDBDIRNAME" ]] &&
-   ln -s "$IMDBRELPATH" "$GLROOT$SYMLINK_PATH/$SORT_BY_SCORE_NAME/$SCORE/$IMDBDIRNAME"
+   ln -s "$(relative_target 2)" "$GLROOT$SYMLINK_PATH/$SORT_BY_SCORE_NAME/$SCORE/$IMDBDIRNAME"
  fi
 fi
 
@@ -522,7 +495,7 @@ if [ $SORT_BY_TITLE -eq 1 ]; then
  # Make link if needed
  if [ ! -z "$IMDBNAME" ] && [ ! $ISEXEMPT -eq 1 ]; then
   SECTION="`echo "$IMDBRELPATH" | tr ' ' '_' | tr '/' ' ' | wc -w | tr -d ' '`"
-  SECTIONNAME="`echo "$IMDBRELPATH" | cut -d '/' -f $SECTION`"
+  SECTIONNAME="`echo "$IMDBRELPATH" | cut -d '/' -f "$SECTION"`"
   MYYEAR="`echo "$IMDBYEAR" | tr -cd '0-9'`"
   TITLECHAR=${IMDBNAME:0:1}
   if [ "$TITLECHAR" == "$QUOTECHAR" ] && [ "${IMDBNAME: -1:1}" == "$QUOTECHAR" ]; then
@@ -552,12 +525,12 @@ if [ $SORT_BY_TITLE -eq 1 ]; then
   fi
   [[ ! -d "$GLROOT$SYMLINK_PATH/$SORT_BY_TITLE_NAME/$TITLECHAR" ]] &&
    mkdir -pm777 "$GLROOT$SYMLINK_PATH/$SORT_BY_TITLE_NAME/$TITLECHAR"
-  CNTR=""
-  while [ -L "$GLROOT$SYMLINK_PATH/$SORT_BY_TITLE_NAME/$TITLECHAR/$TITLE$CNTR" ] &&
-    [ "$IMDBRELPATH" != "$(readlink "$GLROOT$SYMLINK_PATH/$SORT_BY_TITLE_NAME/$TITLECHAR/$TITLE$CNTR")" ]; do
-   CNTR=$((CNTR+1))
-  done
-  ln -nfs "$IMDBRELPATH" "$GLROOT$SYMLINK_PATH/$SORT_BY_TITLE_NAME/$TITLECHAR/$TITLE$CNTR"
+   CNTR=""
+   while [ -L "$GLROOT$SYMLINK_PATH/$SORT_BY_TITLE_NAME/$TITLECHAR/$TITLE$CNTR" ] &&
+     [ "$(relative_target 2)" != "$(readlink "$GLROOT$SYMLINK_PATH/$SORT_BY_TITLE_NAME/$TITLECHAR/$TITLE$CNTR")" ]; do
+    CNTR=$((CNTR+1))
+   done
+   ln -nfs "$(relative_target 2)" "$GLROOT$SYMLINK_PATH/$SORT_BY_TITLE_NAME/$TITLECHAR/$TITLE$CNTR"
  fi
 fi
 
@@ -577,8 +550,8 @@ if [ $SORT_BY_GROUP -eq 1 ]; then
  if [ ! -z "$IMDBRELPATH" ]; then
   if [ "`basename "$IMDBRELPATH" | tr '-' '\n' | grep -v "^$" | wc -l`" -eq 1 ]; then
     GROUP="$SORT_BY_GROUP_NONE"
-  elif [ ! -z "`echo $IMDBRELPATH | egrep "$SORT_BY_GROUP_SPECIAL"`" ]; then
-    GROUP="`echo "$IMDBRELPATH" | egrep -o "*($SORT_BY_GROUP_SPECIAL)$"`"
+  elif [ ! -z "`echo "$IMDBRELPATH" | grep -E "$SORT_BY_GROUP_SPECIAL"`" ]; then
+    GROUP="`echo "$IMDBRELPATH" | grep -E -o "($SORT_BY_GROUP_SPECIAL)$"`"
   else
     GROUP="`basename "$IMDBRELPATH" | tr '-' '\n' | grep -v "^$" | tail -n 1`"
   fi
@@ -586,7 +559,7 @@ if [ $SORT_BY_GROUP -eq 1 ]; then
    [[ ! -d "$GLROOT$SYMLINK_PATH/$SORT_BY_GROUP_NAME/$GROUP" ]] &&
     mkdir -pm777 "$GLROOT$SYMLINK_PATH/$SORT_BY_GROUP_NAME/$GROUP"
    [[ ! -L "$GLROOT$SYMLINK_PATH/$SORT_BY_GROUP_NAME/$GROUP/$IMDBDIRNAME" ]] &&
-    ln -s "$IMDBRELPATH" "$GLROOT$SYMLINK_PATH/$SORT_BY_GROUP_NAME/$GROUP/$IMDBDIRNAME"
+    ln -s "$(relative_target 2)" "$GLROOT$SYMLINK_PATH/$SORT_BY_GROUP_NAME/$GROUP/$IMDBDIRNAME"
   fi
  fi
 fi
@@ -624,45 +597,23 @@ if [ $SORT_BY_DATE -eq 1 ]; then
     MYDATEGRAB_PATH="$GLROOT$IMDBRELPATH"
    fi
   fi
-  if [ "$SORT_BY_DATE_LS" = "bsd" ]; then
-   if [ ! "$MYDATEGRAB_PATH" = "$GLROOT$IMDBRELPATH" ]; then
-    MYDATEGRAB_YEAR=`ls -lanTt "$MYDATEGRAB_PATH" | awk '{print $9}'`
-    MYDATEGRAB_MONT=`ls -lanTt "$MYDATEGRAB_PATH" | awk '{print $6}'`
-    MYDATEGRAB_DATE=`ls -lanTt "$MYDATEGRAB_PATH" | awk '{print $7}'`
-    MYDATEGRAB_TIME=`ls -lanTt "$MYDATEGRAB_PATH" | awk '{print $8}' | tr ':' ' ' | awk '{print $1$2}'`
-   else
-    MYDATEGRAB_YEAR=`ls -lanTt "$MYDATEGRAB_PATH" | grep -e "\ .$" | awk '{print $9}'`
-    MYDATEGRAB_MONT=`ls -lanTt "$MYDATEGRAB_PATH" | grep -e "\ .$" | awk '{print $6}'`
-    MYDATEGRAB_DATE=`ls -lanTt "$MYDATEGRAB_PATH" | grep -e "\ .$" | awk '{print $7}'`
-    MYDATEGRAB_TIME=`ls -lanTt "$MYDATEGRAB_PATH" | grep -e "\ .$" | awk '{print $8}' | tr ':' ' ' | awk '{print $1$2}'`
-   fi
-  else
-   if [ ! "$MYDATEGRAB_PATH" = "$GLROOT$IMDBRELPATH" ]; then
-    MYDATEGRAB_YEAR=`find "$MYDATEGRAB_PATH" -printf "%Ta %Tb %Td %TT %TY" | awk '{print $5}'`
-    MYDATEGRAB_MONT=`find "$MYDATEGRAB_PATH" -printf "%Ta %Tb %Td %TT %TY" | awk '{print $2}'`
-    MYDATEGRAB_DATE=`find "$MYDATEGRAB_PATH" -printf "%Ta %Tb %Td %TT %TY" | awk '{print $3}'`
-    MYDATEGRAB_TIME=`find "$MYDATEGRAB_PATH" -printf "%Ta %Tb %Td %TT %TY" | awk '{print $4}' | tr ':' ' ' | awk '{print $1$2}'`
-   else
-    MYDATEGRAB_YEAR=`find "$MYDATEGRAB_PATH" -type d -printf "%Ta %Tb %Td %TT %TY" | awk '{print $5}'`
-    MYDATEGRAB_MONT=`find "$MYDATEGRAB_PATH" -type d -printf "%Ta %Tb %Td %TT %TY" | awk '{print $2}'`
-    MYDATEGRAB_DATE=`find "$MYDATEGRAB_PATH" -type d -printf "%Ta %Tb %Td %TT %TY" | awk '{print $3}'`
-    MYDATEGRAB_TIME=`find "$MYDATEGRAB_PATH" -type d -printf "%Ta %Tb %Td %TT %TY" | awk '{print $4}' | tr ':' ' ' | awk '{print $1$2}'`
-   fi
-  fi
-  [[ $MYDATEGRAB_DATE -le 9 ]] &&
-   MYDATEGRAB_DATE="0$MYDATEGRAB_DATE"
-  if [ ! -z "$SORT_BY_DATE_FORMAT" ]; then
+MYDATEGRAB_FULL="$(get_file_date "$MYDATEGRAB_PATH")"
+   MYDATEGRAB_YEAR="$(echo "$MYDATEGRAB_FULL" | awk '{print $1}')"
+   MYDATEGRAB_MONT="$(echo "$MYDATEGRAB_FULL" | awk '{print $2}')"
+   MYDATEGRAB_DATE="$(echo "$MYDATEGRAB_FULL" | awk '{print $3}')"
+   MYDATEGRAB_TIME="$(echo "$MYDATEGRAB_FULL" | awk '{print $4}')"
+   if [ ! -z "$SORT_BY_DATE_FORMAT" ]; then
    MYDATE="$SORT_BY_DATE_FORMAT$IMDBDIRNAME"
   else
    MYDATE="`echo "$MYDATEGRAB_YEAR"".""$MYDATEGRAB_MONT"".""$MYDATEGRAB_DATE""-""$MYDATEGRAB_TIME"".-.""$IMDBDIRNAME" | tr -cs '0-9a-zA-Z_\-()\n' '.'`"
   fi
-  MYIMDBDIRNAME="$(echo $IMDBDIRNAME | tr -s ' ' "$SPACE_REPLACER")"
-  [[ ! -z "$SPECIAL_CHAR_REPLACER" ]] && MYIMDBDIRNAME=$(echo "$IMDBNAME" | tr -sc 'A-Za-z0-9_\-(). \n' "$SPECIAL_CHAR_REPLACER")
+   MYIMDBDIRNAME="$(echo "$IMDBDIRNAME" | tr -s ' ' "$SPACE_REPLACER")"
+   [[ ! -z "$SPECIAL_CHAR_REPLACER" ]] && MYIMDBDIRNAME=$(echo "$IMDBNAME" | tr -sc 'A-Za-z0-9_\-(). \n' "$SPECIAL_CHAR_REPLACER")
   MYDELETE="`ls -1F "$GLROOT$SYMLINK_PATH/$SORT_BY_DATE_NAME" | grep -e "@" | grep -e "$MYIMDBDIRNAME" | tr -d '@' | grep -v "^$MYDATE$" | head -n 1`"
   [[ ! -z "$MYDELETE" ]] &&
    rm "$GLROOT$SYMLINK_PATH/$SORT_BY_DATE_NAME/$MYDELETE"
-  if [ ! -L "$GLROOT$SYMLINK_PATH/$SORT_BY_DATE_NAME/$MYDATE" ]; then
-   ln -s "$IMDBRELPATH" "$GLROOT$SYMLINK_PATH/$SORT_BY_DATE_NAME/$MYDATE"
+   if [ ! -L "$GLROOT$SYMLINK_PATH/$SORT_BY_DATE_NAME/$MYDATE" ]; then
+    ln -s "$(relative_target 2)" "$GLROOT$SYMLINK_PATH/$SORT_BY_DATE_NAME/$MYDATE"
    [[ -e "$GLROOT$IMDBRELPATH/.message" ]] &&
     touch -acmr "$GLROOT$IMDBRELPATH/.message" "$GLROOT$SYMLINK_PATH/$SORT_BY_DATE_NAME/$MYDATE"
   fi
@@ -682,30 +633,30 @@ if [ $SORT_BY_TOP250 -eq 1 ]; then
   proc_cleanup_single "$GLROOT$SYMLINK_PATH/$SORT_BY_TOP250_NAME/"
 
  # Make link if needed
- TOP250_RATING=`echo "$IMDBRATING" | grep -e "250:" | grep -e "#" | cut -d "#" -f 2 | tr -cd '0-9'`
- if [ ! -z "$TOP250_RATING" ] && [ ! $ISEXEMPT -eq 1 ]; then
-  if [ $TOP250_RATING -lt 10 ]; then
-   TOP250R="00""$TOP250_RATING"
-  elif [ $TOP250_RATING -lt 100 ]; then
-   TOP250R="0""$TOP250_RATING"
-  else
-   TOP250R="$TOP250_RATING"
-  fi
-  IMDBNAMENEW="$(echo $IMDBNAME | tr -s ' ' "$SPACE_REPLACER" | tr "$BADCHARS" "$BAD_CHAR_REPLACER")"
-  if [[ ! -z "$SPECIAL_CHAR_REPLACER" ]]; then
-   [[ ! -z "$SPECIAL_CHAR_LIST" ]] && [[ ! -z "$SPECIAL_CHAR_SUBS_LIST" ]] &&
-    IMDBNAMENEW=$(echo "$IMDBNAMENEW" | sed "y/$SPECIAL_CHAR_LIST/$SPECIAL_CHAR_SUBS_LIST/")
-   IMDBNAMENEW=$(echo "$IMDBNAMENEW" | tr -sc 'A-Za-z0-9_\-(). \n' "$SPECIAL_CHAR_REPLACER")
-  fi
-  TOP250="$TOP250R.-.$IMDBNAMENEW.($IMDBYEAR)"
-  if [ -z "`ls -1F "$GLROOT$SYMLINK_PATH/$SORT_BY_TOP250_NAME" | grep -e "^$TOP250R.-.$IMDBNAMENEW"`" ]; then
-   rm -fr "$GLROOT$SYMLINK_PATH/$SORT_BY_TOP250_NAME/"$TOP250R.-.*
-   rm -fr "$GLROOT$SYMLINK_PATH/$SORT_BY_TOP250_NAME/"*.-.$IMDBNAMENEW.*
-  fi
+  TOP250_RATING=`echo "$IMDBRATING" | grep -e "250:" | grep -e "#" | cut -d "#" -f 2 | tr -cd '0-9'`
+  if [ ! -z "$TOP250_RATING" ] && [ ! $ISEXEMPT -eq 1 ]; then
+   if [ "$TOP250_RATING" -lt 10 ]; then
+    TOP250R="00""$TOP250_RATING"
+   elif [ "$TOP250_RATING" -lt 100 ]; then
+    TOP250R="0""$TOP250_RATING"
+   else
+    TOP250R="$TOP250_RATING"
+   fi
+   IMDBNAMENEW="$(echo "$IMDBNAME" | tr -s ' ' "$SPACE_REPLACER" | tr "$BADCHARS" "$BAD_CHAR_REPLACER")"
+   if [[ ! -z "$SPECIAL_CHAR_REPLACER" ]]; then
+    [[ ! -z "$SPECIAL_CHAR_LIST" ]] && [[ ! -z "$SPECIAL_CHAR_SUBS_LIST" ]] &&
+     IMDBNAMENEW=$(echo "$IMDBNAMENEW" | sed "y/$SPECIAL_CHAR_LIST/$SPECIAL_CHAR_SUBS_LIST/")
+    IMDBNAMENEW=$(echo "$IMDBNAMENEW" | tr -sc 'A-Za-z0-9_\-(). \n' "$SPECIAL_CHAR_REPLACER")
+   fi
+   TOP250="$TOP250R.-.$IMDBNAMENEW.($IMDBYEAR)"
+   if [ -z "`ls -1F "$GLROOT$SYMLINK_PATH/$SORT_BY_TOP250_NAME" | grep -e "^$TOP250R.-.$IMDBNAMENEW"`" ]; then
+    rm -fr "$GLROOT$SYMLINK_PATH/$SORT_BY_TOP250_NAME/$TOP250R.-."*
+    rm -fr "$GLROOT$SYMLINK_PATH/$SORT_BY_TOP250_NAME/"*.-."$IMDBNAMENEW".*
+   fi
   [[ ! -d "$GLROOT$SYMLINK_PATH/$SORT_BY_TOP250_NAME/$TOP250" ]] &&
    mkdir -pm777 "$GLROOT$SYMLINK_PATH/$SORT_BY_TOP250_NAME/$TOP250"
   [[ ! -L "$GLROOT$SYMLINK_PATH/$SORT_BY_TOP250_NAME/$TOP250/$IMDBDIRNAME" ]] &&
-   ln -s "$IMDBRELPATH" "$GLROOT$SYMLINK_PATH/$SORT_BY_TOP250_NAME/$TOP250/$IMDBDIRNAME"
+   ln -s "$(relative_target 2)" "$GLROOT$SYMLINK_PATH/$SORT_BY_TOP250_NAME/$TOP250/$IMDBDIRNAME"
  fi
 fi
 
@@ -715,24 +666,24 @@ fi
 
 if [ ! -z "$SORT_BY_KEYWORD_LIST" ]; then
  if [ $SORT_BY_KEYWORD -eq 1 ]; then
-  for KEYWORD_PAIR in $SORT_BY_KEYWORD_LIST; do
-   KEYWORD_SEARCH=`echo $KEYWORD_PAIR | cut -d '|' -f 1 | tr 'A-Z' 'a-z'`
-   KEYWORD_REPLACE=`echo $KEYWORD_PAIR | cut -d '|' -f 2 | tr -d '\\/\"&'`
-   SORT_BY_KEYWORD_REPLACED=`echo $SORT_BY_KEYWORD_NAME | sed "s/%KEYWORD%/$KEYWORD_REPLACE/g"`
-   [[ ! -d "$GLROOT$SYMLINK_PATH/$SORT_BY_KEYWORD_REPLACED" ]] &&
-    mkdir -pm777 "$GLROOT$SYMLINK_PATH/$SORT_BY_KEYWORD_REPLACED"
+   for KEYWORD_PAIR in $SORT_BY_KEYWORD_LIST; do
+    KEYWORD_SEARCH=`echo "$KEYWORD_PAIR" | cut -d '|' -f 1 | tr 'A-Z' 'a-z'`
+    KEYWORD_REPLACE=`echo "$KEYWORD_PAIR" | cut -d '|' -f 2 | tr -d '\\/\"&'`
+    SORT_BY_KEYWORD_REPLACED=`echo "$SORT_BY_KEYWORD_NAME" | sed "s/%KEYWORD%/$KEYWORD_REPLACE/g"`
+    [[ ! -d "$GLROOT$SYMLINK_PATH/$SORT_BY_KEYWORD_REPLACED" ]] &&
+     mkdir -pm777 "$GLROOT$SYMLINK_PATH/$SORT_BY_KEYWORD_REPLACED"
 
-   # Cleanup Keyword-dirs
-   [[ $CLEANUP_SYMLINKS -eq 1 ]] &&
-    proc_cleanup "$GLROOT$SYMLINK_PATH/$SORT_BY_KEYWORD_REPLACED/"
+    # Cleanup Keyword-dirs
+    [[ $CLEANUP_SYMLINKS -eq 1 ]] &&
+     proc_cleanup "$GLROOT$SYMLINK_PATH/$SORT_BY_KEYWORD_REPLACED/"
 
-   # Make link if needed
-   if [ ! $ISEXEMPT -eq 1 ]; then
-    if [ ! -z "`echo $IMDBDIRNAME | tr '\.\ \-_' '\n' | tr 'A-Z' 'a-z' | grep -e "^$KEYWORD_SEARCH$"`" ]; then
+    # Make link if needed
+    if [ ! $ISEXEMPT -eq 1 ]; then
+     if [ ! -z "`echo "$IMDBDIRNAME" | tr '\.\ \-_' '\n' | tr 'A-Z' 'a-z' | grep -e "^$KEYWORD_SEARCH$"`" ]; then
      [[ ! -d "$GLROOT$SYMLINK_PATH/$SORT_BY_KEYWORD_REPLACED/" ]] &&
       mkdir -pm777 "$GLROOT$SYMLINK_PATH/$SORT_BY_KEYWORD_REPLACED/"
      [[ ! -L "$GLROOT$SYMLINK_PATH/$SORT_BY_KEYWORD_REPLACED/$IMDBDIRNAME" ]] &&
-      ln -s "$IMDBRELPATH" "$GLROOT$SYMLINK_PATH/$SORT_BY_KEYWORD_REPLACED/$IMDBDIRNAME"
+      ln -s "$(relative_target 1)" "$GLROOT$SYMLINK_PATH/$SORT_BY_KEYWORD_REPLACED/$IMDBDIRNAME"
     fi
    fi
   done

--- a/scripts/psxc-imdb/extras/psxc-imdb-find.sh
+++ b/scripts/psxc-imdb/extras/psxc-imdb-find.sh
@@ -44,17 +44,20 @@
 # v3.1  Switch to IMDB GraphQL API (graphql.imdb.com)
 #       Fix JSON escaping in search query using jq
 #       Fix conf path (/mnt/glftpd/etc -> /glftpd/etc)
+# v3.2  Extract shared API library (psxc-imdb-lib.sh)
+#       Unify VERSION strings across suite
 ##################################################
 
 ########
 # CONFIG
 
 # Version. No need to change.
-VERSION="v3.1-graphql"
+VERSION=3.2
 
-# (full) path to psxc-imdb.conf
-PSXC_IMDB_CONF=/glftpd/etc/psxc-imdb.conf
-#PSXC_IMDB_CONF=/etc/psxc-imdb.conf
+# (full) path to psxc-imdb.conf. Leave empty to auto-discover
+# ($GLROOT/etc/psxc-imdb.conf or /etc/psxc-imdb.conf).
+PSXC_IMDB_CONF=""
+#PSXC_IMDB_CONF=/glftpd/etc/psxc-imdb.conf
 
 # max hits listed
 MAXLIST=10
@@ -144,55 +147,28 @@ IMDBSEARCHTITLA=$(echo "$IMDBSEARCHORIG" | sed 's/\([^0-9]*[0-9]\{4\}\).*/\1/')
 IMDBSEARCHTITLE="$(echo $IMDBSEARCHTITLA | tr ' ' '+' | sed 's/+$//')"
 IMDBSEARCHTITLB=$(echo $IMDBSEARCHTITLA)
 
-. $PSXC_IMDB_CONF
-
-if [ -z "$IMDB_GRAPHQL_URL" ]; then
-  IMDB_GRAPHQL_URL="https://graphql.imdb.com/"
-fi
-if [ -z "$IMDBAPI_TIMEOUT" ]; then
-  IMDBAPI_TIMEOUT=30
-fi
-if [ -z "$JQ_BIN" ]; then
-  JQ_BIN="/bin/jq"
-fi
-if [ -z "$USERAGENT" ]; then
-  USERAGENT="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.3"
-fi
-if [ -z "$CURLFLAGS" ]; then
-  CURLFLAGS="-L"
-fi
-
-IMDBLOCAL="$LOCALURL"
-if [ -z "$IMDBLOCAL" ]; then
- IMDBLOCAL="www"
-fi
+# Source shared library for API functions
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$SCRIPT_DIR/psxc-imdb-lib.sh"
+imdb_set_defaults
+imdb_load_config "$PSXC_IMDB_CONF"
 
 if [ -z "$IMDBNOURL" ] && [ $(echo "$IMDBSEARCHWORDS" | wc -w) -eq 1 ]; then
  IMDBSEARCHID="$(echo -n "$IMDBSEARCHWORDS" | tr -cd '0-9')"
  if [ ! -z "$IMDBSEARCHID" ]; then
   IMDBIDWC=$(echo -n "$IMDBSEARCHID" | wc -c)
   if [ $IMDBIDWC -ge 5 ] && [ $IMDBIDWC -le 8 ]; then
-    URLTOUSE="https://$IMDBLOCAL.imdb.com/title/tt$IMDBSEARCHID"
+     URLTOUSE="https://www.imdb.com/title/tt$IMDBSEARCHID"
   fi
  fi
 fi
 
 if [ -z "$URLTOUSE" ]; then
-  SEARCH_QUERY="query{mainSearch(first:${IMDBLIST:-$DEFLIST},options:{searchTerm:\"$(echo "$IMDBSEARCHTITLE" | sed 's/+/%20/g')\"}){edges{node{entity{... on Title{id titleText{text}releaseYear{year}titleType{text}}}}}}}"
-  SEARCH_PAYLOAD=$($JQ_BIN -n --arg q "$SEARCH_QUERY" '{query: $q}')
-  SEARCH_RESPONSE=$(curl $CURLFLAGS -s -A "$USERAGENT" \
-    -H "Content-Type: application/json" \
-    --connect-timeout $IMDBAPI_TIMEOUT \
-    -X POST "$IMDB_GRAPHQL_URL" \
-    -d "$SEARCH_PAYLOAD" 2>/dev/null)
+  SEARCH_QUERY="query{mainSearch(first:${IMDBLIST:-$DEFLIST},options:{searchTerm:\"$(echo "$IMDBSEARCHTITLE" | sed 's/+/ /g')\"}){edges{node{entity{... on Title{id titleText{text}releaseYear{year}titleType{text}}}}}}}"
+  SEARCH_RESPONSE=$(imdb_request "$SEARCH_QUERY")
 
-  if [ $? -gt 0 ] || [ -z "$SEARCH_RESPONSE" ]; then
+  if [ -z "$SEARCH_RESPONSE" ]; then
     echo "$PREWORD Internal Error. GraphQL API may be down, or not answering. Try again later."
-    exit 0
-  fi
-
-  if ! echo "$SEARCH_RESPONSE" | $JQ_BIN -e '.data' >/dev/null 2>&1; then
-    echo "$PREWORD Internal Error. Invalid API response. Try again later."
     exit 0
   fi
 
@@ -218,7 +194,10 @@ if [ -z "$URLTOUSE" ]; then
 
       if [ -n "$RESULT_ID" ] && [ -n "$RESULT_TITLE" ]; then
         DISPLAY_NUM=$((COUNTER + 1))
-        RESULT_URL="https://$IMDBLOCAL.imdb.com/title/$RESULT_ID"
+        RESULT_URL="https://www.imdb.com/title/$RESULT_ID"
+        if [ ! -z "$LOCALURL" ]; then
+          RESULT_URL="$(imdb_localize_url "$RESULT_URL" "$LOCALURL")"
+        fi
         if [ -n "$RESULT_YEAR" ]; then
           echo "$PREWORD $DISPLAY_NUM. ($RESULT_URL) $RESULT_TITLE ($RESULT_YEAR) [$RESULT_TYPE]"
         else
@@ -238,7 +217,10 @@ if [ -z "$URLTOUSE" ]; then
 fi
 
 if [ ! -z "$URLTOUSE" ]; then
- URLTOSHOW=$(echo $URLTOUSE | sed "s|/www.|/$IMDBLOCAL.|")
+ if [ ! -z "$LOCALURL" ]; then
+  URLTOUSE="$(imdb_localize_url "$URLTOUSE" "$LOCALURL")"
+ fi
+ URLTOSHOW=$URLTOUSE
  if [ -z "$VERBOSE" ] && [ -z "$IMDBPRIVATE" ]; then
   if [ -z "$IMDBLIST" ]; then
    echo -n "$PREWORD '$IMDBSEARCHTITLB' found @ ${BOLD}${URLTOSHOW}${BOLD}. "
@@ -247,12 +229,12 @@ if [ ! -z "$URLTOUSE" ]; then
   fi
   echo "Please wait while gathering details.."
  fi
- if [ ! -z "$DEBUG" ]; then
-  echo "$URLTOUSE|/dev/null|$DESTINATION" | sed "s%/|%|%"
- fi
- if [ -z "$IMDBPRIVATE" ]; then
-  echo "$URLTOUSE|/dev/null|$DESTINATION" | sed "s%/|%|%" >>$IMDBLOG
- fi
+  if [ ! -z "$DEBUG" ]; then
+   echo "$URLTOUSE|/dev/null|$DESTINATION"
+  fi
+  if [ -z "$IMDBPRIVATE" ]; then
+   imdb_queue_lookup "$URLTOUSE" "/dev/null|$DESTINATION" "$IMDBLOG"
+  fi
 else
  echo "$PREWORD Sorry, nothing found on '${BOLD}${IMDBSEARCHWORDS}${BOLD}'."
 fi

--- a/scripts/psxc-imdb/extras/psxc-imdb-parser.sh
+++ b/scripts/psxc-imdb/extras/psxc-imdb-parser.sh
@@ -8,51 +8,14 @@
 # and don't mind spreading the wealth, please send it to me so I can include
 # it.
 #
-VERSION=2.5
+VERSION=3.2
 
-IFSORIG=$IFS
-IFS="^"
+# Source shared library for API functions
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$SCRIPT_DIR/psxc-imdb-lib.sh"
 
-# Initialize variables. bash is a bit limited, so we gotta do a "hack"
-c=1
-for a in `echo $@ | sed "s|\" \"|^|g"`; do
-b[c]=$a
-let c=c+1
-done
-
-IFS=$IFSORIG
-
-# Give the variables some sensible names
-IMDBDATE=${b[1]}
-IMDBDOTFILE=${b[2]}
-IMDBRELPATH=${b[3]}
-IMDBDIRNAME=${b[4]}
-IMDBURL=${b[5]}
-IMDBTITLE=${b[6]}
-IMDBGENRE=${b[7]}
-IMDBRATING=${b[8]}
-IMDBCOUNTRY=${b[9]}
-IMDBLANGUAGE=${b[10]}
-IMDBCERTIFICATION=${b[11]}
-IMDBRUNTIME=${b[12]}
-IMDBDIRECTOR=${b[13]}
-IMDBBUSINESSDATA=${b[14]}
-IMDBPREMIERE=${b[15]}
-IMDBLIMITED=${b[16]}
-IMDBVOTES=${b[17]}
-IMDBSCORE=${b[18]}
-IMDBNAME=${b[19]}
-IMDBYEAR=${b[20]}
-IMDBNUMSCREENS=${b[21]}
-IMDBISLIMITED=${b[22]}
-IMDBCASTLEADNAME=${b[23]}
-IMDBCASTLEADCHAR=${b[24]}
-IMDBTAGLINE=${b[25]}
-IMDBPLOT=${b[26]}
-IMDBBAR=${b[27]}
-IMDBCASTING=${b[28]}
-IMDBCOMMENTSHORT=${b[29]}
-IMDBCOMMENTFULL=${b[30]}
+# Parse IMDB positional arguments using shared function from psxc-imdb-lib.sh
+parse_imdb_args "$@"
 
 #########################################################################
 # From here on you should just paste/format the output to your liking.

--- a/scripts/psxc-imdb/extras/psxc-imdb-rescan.sh
+++ b/scripts/psxc-imdb/extras/psxc-imdb-rescan.sh
@@ -17,10 +17,11 @@
 ########
 
 # Version. No need to change
-VERSION=2.9w
+VERSION=3.2
 
-# Path to psxc-imdb.sh. This is relative to GLROOT.
-PSXC_IMDB=/bin/psxc-imdb.sh
+# Path to psxc-imdb.sh. Auto-detected from this script's location
+# (both are deployed to the same dir, e.g. /bin inside the chroot).
+PSXC_IMDB="$(cd "$(dirname "$0")" && pwd)/psxc-imdb.sh"
 
 # Directories and symlinks to exclude, seperated by a |.
 # We don't want to rescan nuked dirs, so put here the output of this line:
@@ -72,18 +73,16 @@ if [ $# -eq 0 ]; then
 fi
 ARG=$1
 
-PSXC_CONF="`cat "$PSXC_IMDB" | grep -e "^CONFFILE" | head -n 1 | cut -d '=' -f 2`"
-. $PSXC_CONF
+# Source shared library and load psxc-imdb.conf (GLROOT's single source
+# of truth, auto-discovered from this script's location or /etc).
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$SCRIPT_DIR/psxc-imdb-lib.sh"
+imdb_set_defaults
+imdb_load_config || exit 1
 
-if [ ! -z $GLROOT ]; then
- MYTMPFILE="`echo "$TMPFILE" | sed "s%$GLROOT%%"`"
- MYTMPRESCANFILE="`echo "$TMPRESCANFILE" | sed "s%$GLROOT%%"`"
- IMDBPIDCHROOTED="`echo "$IMDBPID" | sed "s%$GLROOT%%"`"
-else
-  MYTMPFILE=$TMPFILE
-  MYTMPRESCANFILE=$TMPRESCANFILE
-  IMDBPIDCHROOTED=$IMDBPID
-fi
+MYTMPFILE=$(strip_glroot "$TMPFILE")
+MYTMPRESCANFILE=$(strip_glroot "$TMPRESCANFILE")
+IMDBPIDCHROOTED=$(strip_glroot "$IMDBPID")
 
 echo "Checking to see if psxc-imdb is running..."
 # If the PID is -1, it means we had psxc-imdb-rescan started in queuemode before
@@ -136,7 +135,7 @@ if [ ! "$ARG" = "-r" ]; then
  proc_doscan
 else
  echo "Scanning recursively for iMDB info.."
- for REL_DIR in `ls -1F | egrep "@$|/$" | grep -E -v "($EXCLUDES)" | tr ' ' '%'`; do
+ for REL_DIR in `ls -1F | grep -E "@$|/$" | grep -E -v "($EXCLUDES)" | tr ' ' '%'`; do
   REL_DIR="`echo $REL_DIR | tr '%@' ' /'`"
   echo "$REL_DIR ..."
   cd "$REL_DIR"

--- a/scripts/psxc-imdb/extras/psxc-imdb-sanity.sh
+++ b/scripts/psxc-imdb/extras/psxc-imdb-sanity.sh
@@ -9,45 +9,23 @@
 # and chmod'ed world read-writable.
 
 # version number. do not change.
-VERSION="v3.1-graphql"
+VERSION="v3.2"
 
 # needed binaries. do not change.
 BINARIES="date cat echo cut curl jq grep head sed awk fold rm bash ls basename dirname chmod ps wc"
 BINARIESCHROOT="wc grep tr sed head echo bash chmod basename pwd curl jq"
-
-# your glftpd root path.
-GLROOT=/glftpd
-
-# path to the config file when chrooted by glftpd.
-CONFFILE=/etc/psxc-imdb.conf
 
 ## End of config ##
 ###################
 
 ######################################################################################################
 
-# check if configfile exists
-############################
+# Source shared library for API functions
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$SCRIPT_DIR/psxc-imdb-lib.sh"
 
-MYGLROOT=$GLROOT
-if [ -r $MYGLROOT$CONFFILE ]; then
- . $MYGLROOT$CONFFILE
- if [ $? -ne 0 ]; then
-  echo "Unable to open config file ($MYGLROOT$CONFFILE). Forced to exit."
-  exit 0
- fi
-elif [ -r $CONFFILE ]; then
- . $CONFFILE
- if [ $? -ne 0 ]; then
-  echo "Unable to open config file ($CONFFILE). Forced to exit."
-  exit 0
- fi
-else
- echo "Config file not found. Forced to exit."
- exit 0
-fi
-CHGLROOT=$GLROOT
-GLROOT=$MYGLROOT
+imdb_set_defaults
+imdb_load_config || exit 0
   clear
   echo "This script will do a few things to make sure the script can be run"
   echo "without too much fuss. First it will check to see if all binaries are"
@@ -86,9 +64,6 @@ GLROOT=$MYGLROOT
   echo "Press <RETURN> or 'depcheck' to Start, <CTRL-C> to Break"; read line;
   echo ""
   echo "Searching in $GLROOT/bin: "
-  if [ ! "$CHGLROOT" = "$GLROOT" ]; then
-   BINARIESCHROOT="$BINARIESCHROOT $BINARIES"
-  fi
   for BINAR in $BINARIESCHROOT; do
    if [ "$line" = "depcheck" ]; then
     echo "removing $BINAR"
@@ -232,12 +207,17 @@ GLROOT=$MYGLROOT
    echo "$jqtest"
   fi
   echo -n "Verifying that IMDB GraphQL API is reachable ..."
-  apitest=$(curl -s -A "psxc-imdb-sanity" --connect-timeout 10 -X POST -H "Content-Type: application/json" -d '{"query":"query{title(id:\"tt0111161\"){titleText{text}}}"}' https://graphql.imdb.com/ 2>&1 | jq -r '.data.title.titleText.text' 2>&1)
+  SANITY_QUERY='query{title(id:"tt0111161"){titleText{text}}}'
+  SANITY_RESPONSE=$(imdb_request "$SANITY_QUERY")
+  apitest=""
+  if [ -n "$SANITY_RESPONSE" ]; then
+   apitest=$($JQ_BIN -r '.data.title.titleText.text // empty' <<< "$SANITY_RESPONSE" 2>/dev/null)
+  fi
   if [ "$apitest" = "The Shawshank Redemption" ]; then
    echo " looks good."
   else
    echo " GraphQL API test failed. Please check your connection."
-   echo "    Response: $apitest"
+   echo "    Response: ${apitest:-<empty>}"
   fi
   echo -n "Checking for locale settings ..."
   if [ -z "$LC_ALL" ]; then
@@ -263,11 +243,6 @@ GLROOT=$MYGLROOT
    echo "    Please fix."
   else
    echo "OK."
-  fi
-  if [ ! "$CHGLROOT" = "$GLROOT" ]; then
-   echo "You seem to run psxc-imdb totally under chroot."
-   echo "Make sure curl and jq are available in $GLROOT/bin/"
-   echo ""
   fi
   echo ""
   echo "Done testing."

--- a/scripts/psxc-imdb/installer.sh
+++ b/scripts/psxc-imdb/installer.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=3.1
+VERSION=3.2
 
 ############################################################################
 # some variables.                                                          #
@@ -15,7 +15,11 @@ installdir=.install
 installvars=.install.vars
 backupdir=.backup_`date +%Y%m%d-%H%M.%S`
 
-scrlist="psxc-imdb.conf|c psxc-imdb-nuker.sh|g psxc-symlink-maker.sh|g psxc-imdb-dotimdb.pl|g psxc-imdb-rescan.sh|g psxc-imdb-find.sh|g psxc-imdb-sanity.sh|g psxc-imdb.tcl|s psxc-imdb.zpt|s psxc-imdb.sh|g"
+scrlist="psxc-imdb.conf|c psxc-imdb-lib.sh|g psxc-imdb-nuker.sh|g psxc-symlink-maker.sh|g psxc-imdb-dotimdb.pl|g psxc-imdb-rescan.sh|g psxc-imdb-find.sh|g psxc-imdb-sanity.sh|g psxc-imdb.tcl|s psxc-imdb.zpt|s psxc-imdb.sh|g"
+
+# Files that genuinely need editing/checking to work. The rest work with
+# defaults or inherit their config from psxc-imdb.conf.
+editables="psxc-imdb.conf psxc-imdb.tcl psxc-symlink-maker.sh psxc-imdb-nuker.sh"
 
 #                                                                          #
 ############################################################################
@@ -87,6 +91,146 @@ check_id ()
  fi
 }
 
+find_binary() {
+  local binary="$1"
+  local search_paths="/usr/local/bin /usr/bin /bin /usr/sbin /sbin"
+  
+  for path in $search_paths; do
+    if [ -x "$path/$binary" ]; then
+      echo "$path/$binary"
+      return 0
+    fi
+  done
+  
+  # Fallback to PATH search
+  if command -v "$binary" >/dev/null 2>&1; then
+    command -v "$binary"
+    return 0
+  fi
+  
+  return 1
+}
+
+detect_os() {
+  if [ "$(uname)" = "FreeBSD" ]; then
+    echo "freebsd"
+  elif [ -f /etc/debian_version ]; then
+    echo "debian"
+  elif [ -f /etc/redhat-release ] || [ -f /etc/centos-release ] || [ -f /etc/fedora-release ]; then
+    echo "redhat"
+  elif [ -f /etc/SuSE-release ] || [ -f /etc/SUSE-brand ]; then
+    echo "suse"
+  elif [ -f /etc/alpine-release ]; then
+    echo "alpine"
+  else
+    echo "linux"
+  fi
+}
+
+check_required_binaries() {
+  local os_type=$(detect_os)
+  local missing_critical=""
+  local missing_optional=""
+  
+  echo ""
+  echo "Checking required binaries..."
+  echo ""
+  
+  # Critical binaries (must have)
+  for binary in bash jq curl; do
+    local path=$(find_binary "$binary")
+    if [ -z "$path" ]; then
+      missing_critical="$missing_critical $binary"
+      echo "  [X] $binary: NOT FOUND"
+    else
+      # Store detected path for later use
+      eval "BINARY_$(echo $binary | tr 'a-z' 'A-Z')=\"$path\""
+      echo "  [OK] $binary: $path"
+    fi
+  done
+  
+  # Check bash version (must be 4+)
+  if [ -n "$BINARY_BASH" ]; then
+    local bash_version=$("$BINARY_BASH" --version 2>/dev/null | head -n1 | grep -oE '[0-9]+\.[0-9]+' | cut -d'.' -f1)
+    if [ -z "$bash_version" ] || [ "$bash_version" -lt 4 ]; then
+      echo "  [X] bash version: $bash_version (version 4+ required)"
+      missing_critical="$missing_critical bash-4+"
+    else
+      echo "  [OK] bash version: $bash_version (OK)"
+    fi
+  fi
+  
+  # Optional but recommended binaries
+  for binary in grep sed awk tr cut head tail wc stat find; do
+    local path=$(find_binary "$binary")
+    if [ -z "$path" ]; then
+      missing_optional="$missing_optional $binary"
+      echo "  [X] $binary: NOT FOUND (optional)"
+    else
+      eval "BINARY_$(echo $binary | tr 'a-z' 'A-Z')=\"$path\""
+      echo "  [OK] $binary: found"
+    fi
+  done
+  
+  echo ""
+  
+  # Handle missing critical binaries
+  if [ -n "$missing_critical" ]; then
+    echo "---------------------------------------------------------------"
+    echo "ERROR: Critical binaries missing:$missing_critical"
+    echo "---------------------------------------------------------------"
+    echo ""
+    echo "Installation hints for your system ($os_type):"
+    echo ""
+    
+    case "$os_type" in
+      freebsd)
+        echo "  sudo pkg install jq curl bash"
+        echo ""
+        echo "  Note: On FreeBSD, these will be installed to /usr/local/bin"
+        ;;
+      debian)
+        echo "  sudo apt-get update"
+        echo "  sudo apt-get install jq curl bash"
+        ;;
+      redhat)
+        echo "  sudo yum install jq curl bash"
+        echo "  # or on newer systems (RHEL 8+, Fedora 22+):"
+        echo "  sudo dnf install jq curl bash"
+        ;;
+      suse)
+        echo "  sudo zypper install jq curl bash"
+        ;;
+      alpine)
+        echo "  sudo apk add jq curl bash"
+        ;;
+      *)
+        echo "  Please install the missing packages using your system's package manager."
+        echo "  Required: jq, curl, bash (version 4 or higher)"
+        ;;
+    esac
+    
+    echo ""
+    echo "---------------------------------------------------------------"
+    read -p "Continue anyway? (NOT recommended) [y/N] " -n 1 -r
+    echo ""
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+      exit 1
+    fi
+    echo ""
+  fi
+  
+  # Warn about missing optional binaries
+  if [ -n "$missing_optional" ]; then
+    echo "WARNING: Some optional binaries are missing:$missing_optional"
+    echo "Some features may not work correctly."
+    echo ""
+  fi
+  
+  echo "Binary check complete."
+  echo ""
+}
+
 find_glpaths ()
 {
 # Try to find glftpd.conf and the rootpath for glftpd.
@@ -113,10 +257,10 @@ find_glpaths ()
   if [ ! -z "$GLFTPD_CONF" ]; then
    GLROOT="`cat $GLFTPD_CONF | grep ^rootpath | awk '{print $2}'`"
   fi
-  if [ -z "$GLROOT" ] || [ ! -e $GLROOT ]; then
+  if [ -z "$GLROOT" ] || [ ! -e "$GLROOT" ]; then
    GLROOT="/glftpd"
   fi
-  
+
   # In case we grabbed the wrong info, let the user verify.
   GLOK=""
   while [ -z "$GLOK" ]; do
@@ -136,7 +280,7 @@ find_glpaths ()
    if [ ! -z $line ]; then
     GLFTPD_CONF="$line"
    fi
-   if [ -d $GLROOT ]; then
+   if [ -d "$GLROOT" ]; then
     if [ -e $GLFTPD_CONF ]; then
      GLOK="YES"
     fi
@@ -335,11 +479,10 @@ readyfiles()
   read line
  fi
 }
-
 glmodify ()
 {
  if [ -r $1 ]; then
-  cat $1 | tr -d '' | sed "s|/etc/glftpd.conf|$GLFTPD_CONF|g" | \
+  cat $1 | LC_ALL=C tr -d '\r' | sed "s|/etc/glftpd.conf|$GLFTPD_CONF|g" | \
    sed "s|/glftpd/|$GLROOT/|g" | sed "s|/glftpd$|$GLROOT|g" | \
    sed "s|/glftpd |$GLROOT |g" | sed "s|/glftpd\"|$GLROOT\"|g" | \
    sed "s|/ftp-data/|$GLDATA/|g" | sed "s|/ftp-data$|$GLDATA|g" | \
@@ -407,13 +550,15 @@ copy_scripts ()
      echo "... copying $scrname to $scrpath" | fold -s -w $foldline
      cp -fRp $installdir/$scrname $scrpath/ || echo "Failed."
     fi
-    echo ""
-    echo -n "Do you wish to edit/check the config in $scrname? [y]> " | fold -s -w $foldline
-    read line
-    if [ -z "$line" ] || [ "$line" = "y" ]; then
-     $EDITOR $scrpath/$scrname
+    if [ ! -z "`echo " $editables " | grep -o " $scrname "`" ]; then
+     echo ""
+     echo -n "Do you wish to edit/check the config in $scrname? [y]> " | fold -s -w $foldline
+     read line
+     if [ -z "$line" ] || [ "$line" = "y" ]; then
+      $EDITOR $scrpath/$scrname
+     fi
+     echo ""
     fi
-    echo ""
    fi
   fi
  done
@@ -438,12 +583,12 @@ modify_glftpd_conf ()
      doexecall=`nl -ba $GLFTPD_CONF | tail -n 1 | awk '{print $1}'`
      if [ ! -z "$doexecnr" ]; then
       head -n $doexecnr $GLFTPD_CONF >$tmpfile
-      echo -e "show_diz\t$dotimdb\t*" >>$tmpfile
+      printf "show_diz\t%s\t*\n" "$dotimdb" >>$tmpfile
       let doexec=doexecall-doexecnr
       tail -n $doexec $GLFTPD_CONF >>$tmpfile
       cat $tmpfile >$GLFTPD_CONF
      else
-      echo -e "show_diz\t$dotimdb\t*" >>$GLFTPD_CONF
+      printf "show_diz\t%s\t*\n" "$dotimdb" >>$GLFTPD_CONF
      fi
      echo "$dotimdb added to show_diz"
     fi
@@ -455,23 +600,23 @@ modify_glftpd_conf ()
    doexecall=`nl -ba $GLFTPD_CONF | tail -n 1 | awk '{print $1}'`
    if [ ! -z "$doexecnr" ]; then
     head -n $doexecnr $GLFTPD_CONF >$tmpfile
-    echo -e "site_cmd\tIMDB-RESCAN\tEXEC\t/bin/psxc-imdb-rescan.sh" >>$tmpfile
+    printf "site_cmd\tIMDB-RESCAN\tEXEC\t/bin/psxc-imdb-rescan.sh\n" >>$tmpfile
     let doexec=doexecall-doexecnr
     tail -n $doexec $GLFTPD_CONF >>$tmpfile
     cat $tmpfile >$GLFTPD_CONF
    else
-    echo -e "site_cmd\tIMDB-RESCAN\tEXEC\t/bin/psxc-imdb-rescan.sh" >>$GLFTPD_CONF
+    printf "site_cmd\tIMDB-RESCAN\tEXEC\t/bin/psxc-imdb-rescan.sh\n" >>$GLFTPD_CONF
    fi
    docustomnr=`nl -ba $GLFTPD_CONF | awk '{print $2,$1}' | grep -e "^custom" | tail -n 1 | awk '{print $2}'`
    docustomall=`nl -ba $GLFTPD_CONF | tail -n 1 | awk '{print $1}'`
    if [ ! -z "$docustomnr" ]; then
     head -n $docustomnr $GLFTPD_CONF >$tmpfile
-    echo -e "custom-imdb-rescan\t1" >>$tmpfile
+    printf "custom-imdb-rescan\t1\n" >>$tmpfile
     let docustom=docustomall-docustomnr
     tail -n $docustom $GLFTPD_CONF >>$tmpfile
     cat $tmpfile >$GLFTPD_CONF
    else
-    echo -e "custom-imdb-rescan\t1" >>$GLFTPD_CONF
+    printf "custom-imdb-rescan\t1\n" >>$GLFTPD_CONF
    fi
    echo "imdb-rescan added as a site command (flag 1 users only)"
    echo "backup of the old file is in $backupdir"
@@ -502,7 +647,7 @@ modify_crontab ()
    fi
   done
   crontab -u $cronname -l | grep -v "psxc-imdb.sh" >$tmpfile 2>/dev/null
-  echo -e "*/10\t*\t*\t*\t*\t$GLROOT/bin/psxc-imdb.sh" >>$tmpfile
+  printf "*/10\t*\t*\t*\t*\t%s/bin/psxc-imdb.sh\n" "$GLROOT" >>$tmpfile
   crontab -u $cronname $tmpfile
   echo ""
   echo "crontab edited - it will now run the imdb-script every 10 minutes. Edit this"
@@ -525,12 +670,12 @@ modify_eggdrop_conf ()
    doeggall=`nl -ba $GLBOT/$EGGDROP_CONF | tail -n 1 | awk '{print $1}'`
    if [ ! -z "$doeggnr" ]; then
     head -n $doeggnr $GLBOT/$EGGDROP_CONF >$tmpfile
-    echo -e "source\t$GLBOTPATH/pzs-ng/plugins/psxc-imdb.tcl" >>$tmpfile
+    printf "source\t%s/pzs-ng/plugins/psxc-imdb.tcl\n" "$GLBOTPATH" >>$tmpfile
     let doegg=doeggall-doeggnr
     tail -n $doegg $GLBOT/$EGGDROP_CONF >>$tmpfile
     cat $tmpfile >$GLBOT/$EGGDROP_CONF
    else
-    echo -e "source\t$GLBOTPATH/pzs-ng/plugins/psxc-imdb.tcl" >>$GLBOT/$EGGDROP_CONF
+    printf "source\t%s/pzs-ng/plugins/psxc-imdb.tcl\n" "$GLBOTPATH" >>$GLBOT/$EGGDROP_CONF
    fi
    echo "$GLBOTPATH/pzs-ng/plugins/psxc-imdb.tcl added to list of sources" | fold -s -w $foldline
   fi
@@ -693,6 +838,7 @@ start_menu ()
 }
 
 check_id
+check_required_binaries
 check_dir
 if [ -e $installvars ]; then
  . $installvars

--- a/scripts/psxc-imdb/main/psxc-imdb-lib.sh
+++ b/scripts/psxc-imdb/main/psxc-imdb-lib.sh
@@ -1,0 +1,368 @@
+#!/bin/bash
+# psxc-imdb-lib.sh - Shared API connection library for psxc-imdb suite
+# Source this file from psxc-imdb scripts to use common functions.
+#
+# Usage: . /path/to/psxc-imdb-lib.sh
+#        imdb_set_defaults
+#        response=$(imdb_request "<query>")
+
+# Set default config values.
+# COUNTRY_MAP and LANGUAGE_MAP are only set if unset, so callers can
+# override them after sourcing the lib but before calling this function.
+# Usage: imdb_set_defaults
+imdb_set_defaults() {
+  : ${CONFFILE:=/etc/psxc-imdb.conf}
+  : ${IMDB_GRAPHQL_URL:=https://graphql.imdb.com/}
+  : ${IMDBAPI_TIMEOUT:=5}
+  : ${API_RETRY_COUNT:=1}
+  : ${API_RETRY_DELAY:=0}
+  if [ -z "$JQ_BIN" ]; then
+    if   [ -n "$SCRIPT_DIR" ] && [ -x "$SCRIPT_DIR/jq" ]; then JQ_BIN="$SCRIPT_DIR/jq"
+    elif [ -x /bin/jq ];        then JQ_BIN=/bin/jq
+    elif command -v jq >/dev/null 2>&1; then JQ_BIN="$(command -v jq)"
+    else JQ_BIN=/bin/jq
+    fi
+  fi
+  : ${USERAGENT:=Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.3}
+  : ${CURLFLAGS:=--max-time 8 -L}
+  : ${CERTCOUNTRY:=US}
+  : ${PREMIERECOUNTRY:=US}
+
+  : ${COUNTRY_MAP:='{"US":"United States","GB":"United Kingdom","AU":"Australia","CA":"Canada","FR":"France","DE":"Germany","IT":"Italy","ES":"Spain","JP":"Japan","KR":"South Korea","CN":"China","IN":"India","RU":"Russia","BR":"Brazil","MX":"Mexico","NL":"Netherlands","SE":"Sweden","NO":"Norway","DK":"Denmark","FI":"Finland","PL":"Poland","CZ":"Czech Republic","AT":"Austria","CH":"Switzerland","BE":"Belgium","PT":"Portugal","IE":"Ireland","NZ":"New Zealand","AR":"Argentina","CL":"Chile","CO":"Colombia","PH":"Philippines","TH":"Thailand","HK":"Hong Kong","SG":"Singapore","TW":"Taiwan","IL":"Israel","TR":"Turkey","ZA":"South Africa","EG":"Egypt","ID":"Indonesia","MY":"Malaysia","VN":"Vietnam","GR":"Greece","HU":"Hungary","RO":"Romania","UA":"Ukraine","HR":"Croatia","RS":"Serbia","IS":"Iceland","LU":"Luxembourg"}'}
+
+  : ${LANGUAGE_MAP:='{"en":"English","fr":"French","de":"German","es":"Spanish","it":"Italian","pt":"Portuguese","ja":"Japanese","ko":"Korean","zh":"Chinese","ru":"Russian","hi":"Hindi","ar":"Arabic","nl":"Dutch","sv":"Swedish","no":"Norwegian","da":"Danish","fi":"Finnish","pl":"Polish","cs":"Czech","hu":"Hungarian","ro":"Romanian","bg":"Bulgarian","uk":"Ukrainian","el":"Greek","tr":"Turkish","th":"Thai","vi":"Vietnamese","id":"Indonesian","ms":"Malay","tl":"Tagalog","he":"Hebrew"}'}
+}
+
+# Load psxc-imdb config file with error handling
+# Usage: imdb_load_config              # auto-discover from the script's location
+#        imdb_load_config "/path/to/psxc-imdb.conf"  # explicit path
+imdb_load_config() {
+  local config_path="${1:-}"
+  if [ -z "$config_path" ]; then
+    for c in "$SCRIPT_DIR/../etc/psxc-imdb.conf" "$CONFFILE"; do
+      [ -r "$c" ] && config_path="$c" && break
+    done
+    if [ -z "$config_path" ]; then
+      echo "Config file not found. Forced to exit." >&2
+      return 1
+    fi
+  fi
+  . "$config_path"
+  if [ $? -ne 0 ]; then
+    echo "Unable to open config file ($config_path). Forced to exit." >&2
+    return 1
+  fi
+}
+
+# Map release-name language tokens to country codes for AKA title lookup.
+# Only declared if bash 4+ (associative array support) is available.
+declare -A LANG_TO_COUNTRY=(
+  [chinese]="CN" [dutch]="NL" [english]="GB" [finnish]="FI" [french]="FR"
+  [german]="DE" [greek]="GR" [hebrew]="IL" [hungarian]="HU" [italian]="IT"
+  [japanese]="JP" [korean]="KR" [norwegian]="NO" [polish]="PL" [portuguese]="PT"
+  [romanian]="RO" [russian]="RU" [spanish]="ES" [swedish]="SE" [turkish]="TR"
+  [nl]="NL" [fr]="FR" [de]="DE" [it]="IT" [es]="ES" [en]="GB"
+  [danish]="DK" [icelandic]="IS" [czech]="CZ"
+)
+
+# Write to glftpd.log in standard psxc-imdb format
+# Usage: imdb_write_log "$message"
+#        imdb_write_log "$message" --usd          # also replaces =$= with USD
+#        imdb_write_log "$message" --usd "$trig"  # with custom trigger
+# Requires: DATE, TRIGGER, IMDBLKL, IMDBDST, GLLOG to be set by caller
+imdb_write_log() {
+  local msg="$1"
+  local use_usd="${2:-}"
+  local trig="$TRIGGER"
+  if [ "$use_usd" = "--usd" ]; then
+    if [ -n "${3:-}" ]; then
+      trig="$3"
+    fi
+    echo "$DATE $trig \"$IMDBLKL\" \"$msg\" \"$IMDBDST\"" | sed 's/\$/USD/g' >> "$GLLOG"
+  else
+    if [ -n "${2:-}" ] && [ "$2" != "--usd" ]; then
+      trig="$2"
+    fi
+    echo "$DATE $trig \"$IMDBLKL\" \"$msg\" \"$IMDBDST\"" >> "$GLLOG"
+  fi
+}
+
+# Add an entry to the IMDB lookup queue
+# Usage: imdb_queue_lookup "$url" "$dest" "$logfile"
+imdb_queue_lookup() {
+  local url="$1"
+  local dest="$2"
+  local logfile="$3"
+  echo "$url|$dest" >> "$logfile"
+}
+
+# Query IMDB GraphQL API with retries
+# Usage: response=$(imdb_request "<query>")
+# Returns: JSON response on success, empty on failure
+imdb_request() {
+  local query="$1"
+  local retries=0
+  local response=""
+  local json_payload
+
+  if [ -n "$JQ_BIN" ] && [ -x "$JQ_BIN" ]; then
+    json_payload=$($JQ_BIN -n --arg q "$query" '{query: $q}')
+  else
+    json_payload="{\"query\": \"$query\"}"
+  fi
+
+  while [ $retries -lt $API_RETRY_COUNT ]; do
+    response=$(curl $CURLFLAGS -s -A "$USERAGENT" \
+      -H "Content-Type: application/json" \
+      -H "Origin: https://www.imdb.com" \
+      -H "Referer: https://www.imdb.com/" \
+      --connect-timeout $IMDBAPI_TIMEOUT \
+      -X POST "$IMDB_GRAPHQL_URL" \
+      -d "$json_payload" 2>/dev/null)
+
+    if [ $? -eq 0 ] && [ -n "$response" ]; then
+      if echo "$response" | $JQ_BIN -e '.data' >/dev/null 2>&1; then
+        echo "$response"
+        return 0
+      fi
+    fi
+    retries=$((retries + 1))
+    sleep $API_RETRY_DELAY
+  done
+  return 1
+}
+
+# Extract IMDB ID from URL
+# Usage: id=$(imdb_extract_id "https://www.imdb.com/title/tt11378946")
+# Returns: IMDB ID (e.g., tt11378946)
+imdb_extract_id() {
+  echo "$1" | sed -n 's/.*\(tt[0-9][0-9]*\).*/\1/p' | head -1
+}
+
+# Rewrite a canonical IMDB URL to include a locale path segment.
+# Usage: localized=$(imdb_localize_url "https://www.imdb.com/title/tt11378946" "de")
+# Returns: https://www.imdb.com/de/title/tt11378946
+# If locale is empty, returns the URL unchanged.
+imdb_localize_url() {
+  local url="$1"
+  local locale="$2"
+  if [ -z "$locale" ]; then
+    echo "$url"
+  else
+    case "$locale" in
+      de|fr|es|it|pt|hi)
+        echo "$url" | sed "s|https://www.imdb.com/title/|https://www.imdb.com/$locale/title/|"
+        ;;
+      *)
+        echo "$url"
+        ;;
+    esac
+  fi
+}
+
+# Parse IMDB positional arguments into variables
+# Usage: parse_imdb_args "$@"
+# Sets: IMDBDATE, IMDBDOTFILE, IMDBRELPATH, IMDBDIRNAME, IMDBURL, IMDBTITLE,
+#       IMDBGENRE, IMDBRATING, IMDBCOUNTRY, IMDBLANGUAGE, IMDBCERTIFICATION,
+#       IMDBRUNTIME, IMDBDIRECTOR, IMDBBUSINESSDATA, IMDBPREMIERE, IMDBLIMITED,
+#       IMDBVOTES, IMDBSCORE, IMDBNAME, IMDBYEAR, IMDBNUMSCREENS, IMDBISLIMITED,
+#       IMDBCASTLEADNAME, IMDBCASTLEADCHAR, IMDBTAGLINE, IMDBPLOT, IMDBBAR,
+#       IMDBCASTING, IMDBCOMMENTSHORT, IMDBCOMMENTFULL, IMDBMETACRITIC
+parse_imdb_args() {
+  local OLDIFS="$IFS"
+  local c=1
+  local a
+  local -a b=()
+  IFS="^"
+  for a in $(echo "$@" | sed "s/^\"//;s/\"$//;s|\" \"|^|g"); do
+    b[c]="$a"
+    let c=c+1
+  done
+  IFS="$OLDIFS"
+
+  IMDBDATE="${b[1]:-}"
+  IMDBDOTFILE="${b[2]:-}"
+  IMDBRELPATH="${b[3]:-}"
+  IMDBDIRNAME="${b[4]:-}"
+  IMDBURL="${b[5]:-}"
+  IMDBTITLE="${b[6]:-}"
+  IMDBGENRE="${b[7]:-}"
+  IMDBRATING="${b[8]:-}"
+  IMDBCOUNTRY="${b[9]:-}"
+  IMDBLANGUAGE="${b[10]:-}"
+  IMDBCERTIFICATION="${b[11]:-}"
+  IMDBRUNTIME="${b[12]:-}"
+  IMDBDIRECTOR="${b[13]:-}"
+  IMDBBUSINESSDATA="${b[14]:-}"
+  IMDBPREMIERE="${b[15]:-}"
+  IMDBLIMITED="${b[16]:-}"
+  IMDBVOTES="${b[17]:-}"
+  IMDBSCORE="${b[18]:-}"
+  IMDBNAME="${b[19]:-}"
+  IMDBYEAR="${b[20]:-}"
+  IMDBNUMSCREENS="${b[21]:-}"
+  IMDBISLIMITED="${b[22]:-}"
+  IMDBCASTLEADNAME="${b[23]:-}"
+  IMDBCASTLEADCHAR="${b[24]:-}"
+  IMDBTAGLINE="${b[25]:-}"
+  IMDBPLOT="${b[26]:-}"
+  IMDBBAR="${b[27]:-}"
+  IMDBCASTING="${b[28]:-}"
+  IMDBCOMMENTSHORT="${b[29]:-}"
+  IMDBCOMMENTFULL="${b[30]:-}"
+  IMDBMETACRITIC="${b[31]:-}"
+}
+
+# Extract the release directory name from a glftpd pre log entry.
+# Usage: DIRNAME=$(imdb_extract_pre_dirname "$PRELOG_LINE" "$PRETRIGGER" "$WORDS" "$SEPARATOR")
+imdb_extract_pre_dirname() {
+  local prelogline="$1"
+  local pretrigger="$2"
+  local words="$3"
+  local separator="$4"
+  local dirname="" c="" b count combine word
+
+  for word in $words; do
+    count=0
+    combine=0
+    if [ -z "$prelogline" ]; then
+      return 1
+    fi
+    if [ -n "$pretrigger" ]; then
+      word=$((word + 1))
+    fi
+    for b in $prelogline; do
+      if { [ -z "$(echo "$b" | grep "$pretrigger")" ] && [ "$count" -gt 0 ]; } || [ -z "$pretrigger" ]; then
+        if [ "$combine" -eq 1 ]; then
+          c="$c$b"
+        else
+          c="$b"
+        fi
+        if [ -n "$(echo "$c" | grep '^"')" ]; then
+          combine=1
+        else
+          c="$b"
+          count=$((count + 1))
+        fi
+        if [ -n "$(echo "$c" | grep '"$')" ]; then
+          combine=0
+          count=$((count + 1))
+        fi
+        if [ "$count" -eq "$word" ]; then
+          break
+        fi
+      else
+        if [ "$b" = "$pretrigger" ]; then
+          count=1
+        fi
+      fi
+    done
+    dirname="$dirname$c"
+  done
+
+  echo "$dirname" | sed "s|\"\"|$separator|g" | sed "s|\"||g"
+}
+
+# Strip GLROOT prefix from path
+# Usage: MYTMPFILE=$(strip_glroot "$TMPFILE")
+strip_glroot() {
+  local path="$1"
+  if [ -n "$GLROOT" ]; then
+    echo "${path#$GLROOT}"
+  else
+    echo "$path"
+  fi
+}
+
+# Resolve the FIXDIRTIME mtime-snapshot carrier path for the current context.
+# The conf's TMPFILE is a host-style path (GLROOT-prefixed); chrooted runs must
+# use the GLROOT-stripped form, host runs the host form. Pick whichever
+# actually resolves here.
+# Usage: DIRDATE_CARRIER=$(imdb_dirdate_carrier)
+imdb_dirdate_carrier() {
+  if [ -d "$(dirname "$TMPFILE")" ]; then
+    echo "${TMPFILE}.dirdate"
+  else
+    echo "$(strip_glroot "$TMPFILE").dirdate"
+  fi
+}
+
+# Extract IMDB URL from NFO file with fallback levels
+# Usage: IMDBURL=$(extract_imdb_url "$FILENAME" "$RELAXEDURLS")
+extract_imdb_url() {
+  local filename="$1"
+  local relaxed="${2:-0}"
+  local url=""
+  local urls=""
+
+  # Level 0: Standard URL format
+  urls="$(grep [Ii][Mm][Dd][Bb] "$filename" | tr ' \|' '\n' | sed -n '/[hH][tT][tT][pP][sS]*:[/][/].*[.][iI][mM][dD][bB][.].*.[0-9]/p' | head -n 1 | tr -c -d '[:alnum:]\:./?')"
+  if [ -n "$(echo "$urls" | grep "imdb\.")" ]; then
+    url="https://www.imdb.com/title/tt$(echo "$urls" | sed "s/=/-/g" | sed "s/imdb\./=/" | cut -d "=" -f 2 | cut -d "/" -f 2,3 | tr -c -d '[:digit:]')"
+    if [ -z "$(echo "$url" | tr -cd '0-9')" ]; then
+      url=""
+    fi
+  fi
+
+  # Level 1: Relaxed URL format
+  if [ -z "$url" ] && [ "$relaxed" -ge 1 ]; then
+    urls="$(grep [Ii][Mm][Dd][Bb] "$filename" | tr ' \|' '\n' | sed -n '/[hH][tT][tT][pP][sS]*:[/][/].*[iI][mM][dD][bB][.].*.[0-9]/p' | head -n 1 | tr -c -d '[:alnum:]\:./?')"
+    if [ -n "$(echo "$urls" | grep "imdb\.")" ]; then
+      url="https://www.imdb.com/title/tt$(echo "$urls" | sed "s/=/-/g" | sed "s/imdb\./=/" | cut -d "=" -f 2 | cut -d "/" -f 2,3 | tr -c -d '[:digit:]')"
+      if [ -z "$(echo "$url" | tr -cd '0-9')" ]; then
+        url=""
+      fi
+    fi
+  fi
+
+  # Level 2: Even more relaxed
+  if [ -z "$url" ] && [ "$relaxed" -ge 2 ]; then
+    urls="$(grep [Ii][Mm][Dd][Bb] "$filename" | tr ' \|' '\n' | sed -n '/.*[iI][mM][dD][bB][.].*.[0-9]/p' | head -n 1 | tr -c -d '[:alnum:]\:./?')"
+    if [ -n "$(echo "$urls" | grep "imdb\.")" ]; then
+      url="https://www.imdb.com/title/tt$(echo "$urls" | sed "s/=/-/g" | sed "s/imdb\./=/" | cut -d "=" -f 2 | cut -d "/" -f 2,3 | tr -c -d '[:digit:]')"
+      if [ -z "$(echo "$url" | tr -cd '0-9')" ]; then
+        url=""
+      fi
+    fi
+  fi
+
+  # Level 3: Numeric extraction
+  if [ -z "$url" ] && [ "$relaxed" -ge 3 ]; then
+    for urls in $(grep [Ii][Mm][Dd][Bb] "$filename" | tr -c '[:digit:]' '\n' | grep -v "^$"); do
+      if [ -n "$(echo "$urls" | tr -cd '0-9')" ]; then
+        if [ "$(echo "$urls" | tr -cd '0-9' | wc -c)" -eq 8 ] || [ "$(echo "$urls" | tr -cd '0-9' | wc -c)" -eq 7 ]; then
+          url="https://www.imdb.com/title/tt$urls"
+          break
+        fi
+      fi
+    done
+  fi
+
+  # Level 4: Broad numeric search
+  if [ -z "$url" ] && [ "$relaxed" -ge 4 ]; then
+    for urls in $(cat "$filename" | tr -c '[:digit:]' '\n' | grep -v "^$"); do
+      if [ "$(echo "$urls" | wc -c)" -eq 8 ] || [ "$(echo "$urls" | wc -c)" -eq 7 ]; then
+        url="https://www.imdb.com/title/tt$urls"
+        break
+      fi
+    done
+  fi
+
+  echo "$url"
+}
+
+# Get file/directory modification date components, platform-agnostic.
+# Usage: get_file_date "$path"
+# Returns: "YEAR MONTH DATE TIME" (e.g. "2026 Aug 15 1430")
+get_file_date() {
+  local path="$1"
+  local findargs=(-printf "%TY %Tb %Td %TH%TM")
+  if [ -d "$path" ]; then
+    findargs=(-type d -printf "%TY %Tb %Td %TH%TM")
+  fi
+  if [ "$SORT_BY_DATE_LS" = "bsd" ]; then
+    stat -f "%Sm" -t "%Y %b %d %H%M" "$path"
+  else
+    find "$path" "${findargs[@]}"
+  fi
+}

--- a/scripts/psxc-imdb/main/psxc-imdb.conf
+++ b/scripts/psxc-imdb/main/psxc-imdb.conf
@@ -31,20 +31,29 @@ DEBUG=""
 ### API Configuration (IMDB GraphQL)                                   ###
 ##########################################################################
 
-# IMDB GraphQL API endpoint
-IMDB_GRAPHQL_URL="https://graphql.imdb.com/"
+# IMDB GraphQL API endpoint (default set in psxc-imdb-lib.sh)
+#IMDB_GRAPHQL_URL="https://graphql.imdb.com/"
 
-# Connection timeout for API requests (in seconds)
-IMDBAPI_TIMEOUT=5
+# Connection timeout for API requests (in seconds) (default set in psxc-imdb-lib.sh)
+#IMDBAPI_TIMEOUT=5
 
-# Number of retries for API requests
-API_RETRY_COUNT=1
+# Number of retries for API requests (default set in psxc-imdb-lib.sh)
+#API_RETRY_COUNT=1
 
-# Delay between retries (in seconds)
-API_RETRY_DELAY=0
+# Delay between retries (in seconds) (default set in psxc-imdb-lib.sh)
+#API_RETRY_DELAY=0
 
-# Path to jq binary (JSON parser) - required for API parsing
-JQ_BIN="/bin/jq"
+# Path to jq binary (JSON parser) - required for API parsing. Auto-detected
+# (defaults to the jq alongside the scripts, e.g. $SCRIPT_DIR/jq). Override here.
+#JQ_BIN=""
+
+# Localized IMDB URL path. Set to a language code to display IMDB links with
+# a localized path segment (e.g. "de" -> www.imdb.com/de/title/tt...).
+# Supported: de (German), fr (French), es (Spanish), it (Italian),
+# pt (Portuguese/Brazil), hi (Hindi). Leave empty (default) for standard
+# English URLs. This affects bot output, .imdb files, and psxc-imdb-find.sh.
+#LOCALURL=""
+LOCALURL=""
 
 # your glftpd root path.
 GLROOT=/glftpd
@@ -127,9 +136,9 @@ USELIMITED=""
 USECERT="YES"
 #USECERT=""
 
-# Country code for premiere/certificate lookups.
-PREMIERECOUNTRY="US"
-CERTCOUNTRY="US"
+# Country code for premiere/certificate lookups. (default set in psxc-imdb-lib.sh)
+#PREMIERECOUNTRY="US"
+#CERTCOUNTRY="US"
 
 # Use the Original Title (the title in the film's production language)?
 # When set to "", the script will look up a localized title from IMDB's
@@ -148,12 +157,12 @@ USEBOM=""
 #USEWIDEST="YES"
 USEWIDEST=""
 
-# The useragent to pass on to IMDB and BOM
-USERAGENT="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.3"
+# The useragent to pass on to IMDB and BOM (default set in psxc-imdb-lib.sh)
+#USERAGENT="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.3"
 
-# cURL flags used. To use a (socks) proxy add:
+# cURL flags used (default set in psxc-imdb-lib.sh). To use a (socks) proxy add:
 #   "--socks5 127.0.0.1:1080" or "--proxy https://127.0.0.1:3218"
-CURLFLAGS="--max-time 8 -L"
+#CURLFLAGS="--max-time 8 -L"
 
 ##########################################################################
 ### DEPRECATED OPTIONS (kept for reference, no longer used)            ###
@@ -182,14 +191,6 @@ RELAXEDURLS="3"    # "ON" is the same as "3"
 # This list is case sensitive, so spell things correctly.
 SCANDIRS=""
 #SCANDIRS="/site/DiVX /site/XViD /site/SVCD /site/VCD /site/MOViES /site/TV-RiPS /site/AFFILS"
-
-# To support international sites, you can change the "us.imdb.com" into a valid
-# url with info written in your language. For instance, to put "german.imdb.com"
-# in channel and the .imdb, set this variable to "german". The default is "" which
-# is equivalent to "us".
-# Note that you'll always get redirected to "https://imdb.com" nowadays
-#LOCALURL=""
-#LOCALURL="swedish"
 
 # When using post_check in glftpd.conf to start this script, it sometimes
 # doesn't receive any arguments passed from glftpd. There is a way around this
@@ -558,6 +559,18 @@ NEWLINE="\\\\n"
 # The default is to have this variable disabled "".
 RUNCONTINOUS=""
 #RUNCONTINOUS="YES"
+
+# FIXDIRTIME: whether the script preserves the release dir's original mtime.
+# When "YES", the dir's mtime is snapshotted before the run and restored
+# afterwards (including after the dummy placeholder files are created and
+# after the info files are written), so the dir date stays unchanged and
+# upload-order dirlists stay intact - e.g. imdb-rescan -r will not rewrite
+# the mtime of every scanned directory. When empty (""), the default, the
+# script never actively touches directory timestamps - note that creating the
+# .imdb/.imdbinfoname files will still bump the dir's mtime to the
+# rescan/run time on the first pass.
+FIXDIRTIME=""
+#FIXDIRTIME="YES"
 
 # END OF CONFIG
 ####################################################################################

--- a/scripts/psxc-imdb/main/psxc-imdb.sh
+++ b/scripts/psxc-imdb/main/psxc-imdb.sh
@@ -3,122 +3,39 @@
 # PSXC IMDB INFO #
 ##################
 
-# Just edit the 2 lines below, then continue on the "real" config file.
-
-# your glftpd root path.
-GLROOT=/glftpd
-
-# path to the config file when chrooted by glftpd.
-CONFFILE=/etc/psxc-imdb.conf
-
-## End of config ##
-###################
-
 # version number. do not change.
-VERSION="v3.1-graphql"
+VERSION="v3.2"
 
 ######################################################################################################
 
 RECVDARGS="$1"
-# check if configfile exists
-############################
-
-if [ -r $GLROOT$CONFFILE ]; then
- . $GLROOT$CONFFILE
- if [ $? -ne 0 ]; then
-  echo "Unable to open config file ($GLROOT$CONFFILE). Forced to exit."
-  exit 0
- fi
-elif [ -r $CONFFILE ]; then
- . $CONFFILE
- if [ $? -ne 0 ]; then
-  echo "Unable to open config file ($CONFFILE). Forced to exit."
-  exit 0
- fi
-else
- echo "Config file not found. Forced to exit."
- exit 0
-fi
-
-# Start debugging
-if [ "$DEBUG" = "ON" ] || [ "$DEBUG" = "2" ]; then
- set -x
-elif [ "$DEBUG" = "3" ]; then
- set -x -v
-elif [ "$DEBUG" = "4" ]; then
- set -x -v
-fi
-
-# Let's hack glftpd
-if [ -z "$RECVDARGS" ] && [ ! -z "$GLFIX" ]; then
- RECVDARGS=$(ls -1Ft | grep -a -v "/" | grep -a -v "@" | head -n 1 | grep -a -e "[.][nN][fF][oO]$")
-fi
 
 # Remove locale settings which might cause problems
 export LC_ALL=""
 export LANG=""
 
-if [ -z "$USERAGENT" ]; then
-  USERAGENT="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.3"
+# Source shared library for API functions
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$SCRIPT_DIR/psxc-imdb-lib.sh"
+imdb_set_defaults
+imdb_load_config || exit 0
+
+# FIXDIRTIME mtime-snapshot carrier, resolved for this run's context
+# (chrooted vs host) so the snapshot/restore works in both.
+DIRDATE_CARRIER="$(imdb_dirdate_carrier)"
+
+# Start debugging
+if [ "$DEBUG" = "ON" ] || [ "$DEBUG" = "2" ]; then
+ set -x
+elif [ "$DEBUG" = "3" ] || [ "$DEBUG" = "4" ]; then
+ # level 4 additionally traces the bash addons (see EXTERNALSCRIPTNAME below)
+ set -x -v
 fi
 
-if [ -z "$IMDB_GRAPHQL_URL" ]; then
-  IMDB_GRAPHQL_URL="https://graphql.imdb.com/"
+# Let's hack glftpd
+if [ -z "$RECVDARGS" ] && [ ! -z "$GLFIX" ]; then
+ RECVDARGS=$(ls -1Ft | grep -v "/" | grep -v "@" | head -n 1 | grep -e "[.][nN][fF][oO]$")
 fi
-if [ -z "$IMDBAPI_TIMEOUT" ]; then
-  IMDBAPI_TIMEOUT=30
-fi
-if [ -z "$API_RETRY_COUNT" ]; then
-  API_RETRY_COUNT=3
-fi
-if [ -z "$API_RETRY_DELAY" ]; then
-  API_RETRY_DELAY=2
-fi
-if [ -z "$JQ_BIN" ]; then
-  JQ_BIN="/bin/jq"
-fi
-if [ -z "$CERTCOUNTRY" ]; then
-  CERTCOUNTRY="US"
-fi
-if [ -z "$PREMIERECOUNTRY" ]; then
-  PREMIERECOUNTRY="US"
-fi
-
-COUNTRY_MAP='{"US":"United States","GB":"United Kingdom","AU":"Australia","CA":"Canada","FR":"France","DE":"Germany","IT":"Italy","ES":"Spain","JP":"Japan","KR":"South Korea","CN":"China","IN":"India","RU":"Russia","BR":"Brazil","MX":"Mexico","NL":"Netherlands","SE":"Sweden","NO":"Norway","DK":"Denmark","FI":"Finland","PL":"Poland","CZ":"Czech Republic","AT":"Austria","CH":"Switzerland","BE":"Belgium","PT":"Portugal","IE":"Ireland","NZ":"New Zealand","AR":"Argentina","CL":"Chile","CO":"Colombia","PH":"Philippines","TH":"Thailand","HK":"Hong Kong","SG":"Singapore","TW":"Taiwan","IL":"Israel","TR":"Turkey","ZA":"South Africa","EG":"Egypt","ID":"Indonesia","MY":"Malaysia","VN":"Vietnam","GR":"Greece","HU":"Hungary","RO":"Romania","UA":"Ukraine","HR":"Croatia","RS":"Serbia","IS":"Iceland","LU":"Luxembourg"}'
-
-LANGUAGE_MAP='{"en":"English","fr":"French","de":"German","es":"Spanish","it":"Italian","pt":"Portuguese","ja":"Japanese","ko":"Korean","zh":"Chinese","ru":"Russian","hi":"Hindi","ar":"Arabic","nl":"Dutch","sv":"Swedish","no":"Norwegian","da":"Danish","fi":"Finnish","pl":"Polish","cs":"Czech","hu":"Hungarian","ro":"Romanian","bg":"Bulgarian","uk":"Ukrainian","el":"Greek","tr":"Turkish","th":"Thai","vi":"Vietnamese","id":"Indonesian","ms":"Malay","tl":"Tagalog","he":"Hebrew"}'
-
-graphql_request() {
-  local query="$1"
-  local retries=0
-  local response=""
-  local json_payload
-  json_payload=$($JQ_BIN -n --arg q "$query" '{query: $q}')
-
-  while [ $retries -lt $API_RETRY_COUNT ]; do
-    response=$(curl $CURLFLAGS -s -A "$USERAGENT" \
-      -H "Content-Type: application/json" \
-      -H "Origin: https://www.imdb.com" \
-      -H "Referer: https://www.imdb.com/" \
-      --connect-timeout $IMDBAPI_TIMEOUT \
-      -X POST "$IMDB_GRAPHQL_URL" \
-      -d "$json_payload" 2>/dev/null)
-    if [ $? -eq 0 ] && [ -n "$response" ]; then
-      if echo "$response" | $JQ_BIN -e '.data' >/dev/null 2>&1; then
-        echo "$response"
-        return 0
-      fi
-    fi
-    retries=$((retries + 1))
-    sleep $API_RETRY_DELAY
-  done
-  return 1
-}
-
-extract_imdb_id() {
-  local url="$1"
-  echo "$url" | grep -oP 'tt[0-9]+' | head -1
-}
 
 if [ ! -z "$RECVDARGS" ]; then
 
@@ -128,30 +45,32 @@ if [ ! -z "$RECVDARGS" ]; then
 # PATH=$PATHCHROOTED
 # IMDBLOG=$IMDBLOGCHROOTED
  FILENAME="$RECVDARGS"
-   if [ ! -z "$GLROOT" ]; then
-    MYTMPFILE=$(echo "$TMPRESCANFILE" | sed "s%$GLROOT%%")
-   else
-    MYTMPFILE=$TMPRESCANFILE
-   fi
-   PSXCFLAG=$(head -n 1 $MYTMPFILE | tr -cd '0-9')
-   if [ ! -z "$PSXCFLAG" ]; then
-    if [ $PSXCFLAG -ge 4 ]; then
-     let PSXCFLAG=PSXCFLAG-4
+   MYTMPFILE=$(strip_glroot "$TMPRESCANFILE")
+   PSXCFLAG=$(head -n 1 "$MYTMPFILE" 2>/dev/null | tr -cd '0-9')
+    if [ ! -z "$PSXCFLAG" ]; then
+     if [ "$PSXCFLAG" -ge 4 ]; then
+      let PSXCFLAG=PSXCFLAG-4
+     fi
+     if [ "$PSXCFLAG" -ge 2 ]; then
+      DOTIMDB=""
+      INFOTEMPNAME=""
+      DOTDATE=""
+      DOTURL=""
+     fi
     fi
-    if [ $PSXCFLAG -ge 2 ]; then
-     DOTIMDB=""
-     INFOTEMPNAME=""
-     DOTDATE=""
-     DOTURL=""
+    # Snapshot the release dir's original date before creating any files in it
+    # (FIXDIRTIME gated); restored at the end of this block and again by the
+    # queue path so upload-order dirlists stay intact.
+    if [ ! -z "$FIXDIRTIME" ]; then
+     touch -r "$(pwd)" "$DIRDATE_CARRIER" >/dev/null 2>&1
     fi
-   fi
-   if [ ! -z "$DOTDATE" ]; then
-    DOTDATEINFO="$(grep -a [Dd][Aa][Tt][Ee] $FILENAME | tr -c '/a-zA-Z0-9:. -/\n' ' ' | tr -s ' ')"
-    if [ ! -z "$DOTDATEINFO" ]; then
-     echo "$DOTDATEINFO" > $DOTDATE
-     chmod 666 $DOTDATE
+    if [ ! -z "$DOTDATE" ]; then
+     DOTDATEINFO="$(grep [Dd][Aa][Tt][Ee] "$FILENAME" | tr -c '/a-zA-Z0-9:. -/\n' ' ' | tr -s ' ')"
+     if [ ! -z "$DOTDATEINFO" ]; then
+      echo "$DOTDATEINFO" > "$DOTDATE"
+      chmod 666 "$DOTDATE"
+     fi
     fi
-   fi
 
 # Should we even begin searching for an url?
    SEARCHFORURLS=0
@@ -159,7 +78,7 @@ if [ ! -z "$RECVDARGS" ]; then
     SEARCHFORURLS=1
    fi
    for SCANDIR in $SCANDIRS; do
-    if [ ! -z "$(pwd | grep -a "$SCANDIR")" ]; then
+    if [ ! -z "$(pwd | grep "$SCANDIR")" ]; then
      SEARCHFORURLS=1
      break
     fi
@@ -177,42 +96,42 @@ if [ ! -z "$RECVDARGS" ]; then
    fi
 
 # Level 0 search
-   IMDBURLS="$(grep -a [Ii][Mm][Dd][Bb] $FILENAME | tr ' \|' '\n' | sed -n /[hH][tT][tT][pP][sS]*:[/][/].*[.][iI][mM][dD][bB][.].*.[0-9]/p | head -n 1 | tr -c -d '[:alnum:]\:./?')"
-   if [ ! -z "$(echo $IMDBURLS | grep -a "imdb\.")" ]; then
-#    IMDBURL="https://www.imdb.com/title/tt""$(echo $IMDBURLS | sed "s/=/-/g" | sed "s/imdb./=/" | cut -d "=" -f 2 | cut -d "/" -f 2,3 | tr -c -d '[:digit:]')"
-    IMDBURL="https://www.imdb.com/title/tt""$(echo $IMDBURLS | sed "s/=/-/g" | sed "s/imdb./=/" | cut -d "=" -f 2 |  grep -a -o "[0-9]*" | head -n 1)"
-    if [ -z $(echo $IMDBURL | tr -cd '0-9') ]; then
+   IMDBURLS="$(grep [Ii][Mm][Dd][Bb] "$FILENAME" | tr ' \|' '\n' | sed -n /[hH][tT][tT][pP][sS]*:[/][/].*[.][iI][mM][dD][bB][.].*.[0-9]/p | head -n 1 | tr -c -d '[:alnum:]\:./?')"
+   if [ ! -z "$(echo "$IMDBURLS" | grep "imdb\.")" ]; then
+#    IMDBURL="https://www.imdb.com/title/tt""$(echo "$IMDBURLS" | sed "s/=/-/g" | sed "s/imdb./=/" | cut -d "=" -f 2 | cut -d "/" -f 2,3 | tr -c -d '[:digit:]')"
+     IMDBURL="https://www.imdb.com/title/tt""$(echo "$IMDBURLS" | sed "s/=/-/g" | sed "s/imdb\./=/" | cut -d "=" -f 2 |  grep -o "[0-9]*" | head -n 1)"
+    if [ -z "$(echo "$IMDBURL" | tr -cd '0-9')" ]; then
      IMDBURL=""
     fi
    fi
 
 # Level 1 search
-   if [ -z "$IMDBURL" ] && [ $RELAXEDURLS -ge 1 ]; then
-    IMDBURLS="$(grep -a [Ii][Mm][Dd][Bb] $FILENAME | tr ' \|' '\n' | sed -n /[hH][tT][tT][pP][sS]*:[/][/].*[iI][mM][dD][bB][.].*.[0-9]/p | head -n 1 | tr -c -d '[:alnum:]\:./?')"
-    if [ ! -z "$(echo $IMDBURLS | grep -a "imdb\.")" ]; then
-     IMDBURL="https://www.imdb.com/title/tt""$(echo $IMDBURLS | sed "s/=/-/g" | sed "s/imdb./=/" | cut -d "=" -f 2 | cut -d "/" -f 2,3 | tr -c -d '[:digit:]')"
-     if [ -z $(echo $IMDBURL | tr -cd '0-9') ]; then
+   if [ -z "$IMDBURL" ] && [ "$RELAXEDURLS" -ge 1 ]; then
+    IMDBURLS="$(grep [Ii][Mm][Dd][Bb] "$FILENAME" | tr ' \|' '\n' | sed -n /[hH][tT][tT][pP][sS]*:[/][/].*[iI][mM][dD][bB][.].*.[0-9]/p | head -n 1 | tr -c -d '[:alnum:]\:./?')"
+    if [ ! -z "$(echo "$IMDBURLS" | grep "imdb\.")" ]; then
+     IMDBURL="https://www.imdb.com/title/tt""$(echo "$IMDBURLS" | sed "s/=/-/g" | sed "s/imdb\./=/" | cut -d "=" -f 2 | cut -d "/" -f 2,3 | tr -c -d '[:digit:]')"
+     if [ -z "$(echo "$IMDBURL" | tr -cd '0-9')" ]; then
       IMDBURL=""
      fi
     fi
    fi
 
 # Level 2 search
-   if [ -z "$IMDBURL" ] && [ $RELAXEDURLS -ge 2 ]; then
-    IMDBURLS="$(grep -a [Ii][Mm][Dd][Bb] $FILENAME | tr ' \|' '\n' | sed -n /.*[iI][mM][dD][bB][.].*.[0-9]/p | head -n 1 | tr -c -d '[:alnum:]\:./?')"
-    if [ ! -z "$(echo $IMDBURLS | grep -a "imdb\.")" ]; then
-     IMDBURL="https://www.imdb.com/title/tt""$(echo $IMDBURLS | sed "s/=/-/g" | sed "s/imdb./=/" | cut -d "=" -f 2 | cut -d "/" -f 2,3 | tr -c -d '[:digit:]')"
-     if [ -z $(echo $IMDBURL | tr -cd '0-9') ]; then
+   if [ -z "$IMDBURL" ] && [ "$RELAXEDURLS" -ge 2 ]; then
+    IMDBURLS="$(grep [Ii][Mm][Dd][Bb] "$FILENAME" | tr ' \|' '\n' | sed -n /.*[iI][mM][dD][bB][.].*.[0-9]/p | head -n 1 | tr -c -d '[:alnum:]\:./?')"
+    if [ ! -z "$(echo "$IMDBURLS" | grep "imdb\.")" ]; then
+     IMDBURL="https://www.imdb.com/title/tt""$(echo "$IMDBURLS" | sed "s/=/-/g" | sed "s/imdb\./=/" | cut -d "=" -f 2 | cut -d "/" -f 2,3 | tr -c -d '[:digit:]')"
+     if [ -z "$(echo "$IMDBURL" | tr -cd '0-9')" ]; then
       IMDBURL=""
      fi
     fi
    fi
 
 # Level 3 search
-   if [ -z "$IMDBURL" ] && [ $RELAXEDURLS -ge 3 ]; then
-    for IMDBURLS in $(grep -a [Ii][Mm][Dd][Bb] $FILENAME | tr -c '[:digit:]' '\n' | grep -a -v "^$"); do
-     if [ ! -z $(echo $IMDBURLS | tr -cd '0-9') ]; then
-      if [ $(echo $IMDBURLS | tr -cd '0-9' | wc -c) -eq 8 ] || [ $(echo $IMDBURLS | tr -cd '0-9' | wc -c) -eq 7 ]; then
+   if [ -z "$IMDBURL" ] && [ "$RELAXEDURLS" -ge 3 ]; then
+    for IMDBURLS in $(grep [Ii][Mm][Dd][Bb] "$FILENAME" | tr -c '[:digit:]' '\n' | grep -v "^$"); do
+     if [ ! -z "$(echo "$IMDBURLS" | tr -cd '0-9')" ]; then
+      if [ "$(echo "$IMDBURLS" | tr -cd '0-9' | wc -c)" -eq 8 ] || [ "$(echo "$IMDBURLS" | tr -cd '0-9' | wc -c)" -eq 7 ]; then
        IMDBURL="$IMDBURLS"
        break
       fi
@@ -224,9 +143,9 @@ if [ ! -z "$RECVDARGS" ]; then
    fi
 
 # Level 4 search
-   if [ -z "$IMDBURL" ] && [ $RELAXEDURLS -ge 4 ]; then
-    for IMDBURLS in $(cat $FILENAME | tr -c '[:digit:]' '\n' | grep -a -v "^$"); do
-     if [ $(echo $IMDBURLS | wc -c) -eq 8 ] || [ $(echo $IMDBURLS | wc -c) -eq 7 ]; then
+   if [ -z "$IMDBURL" ] && [ "$RELAXEDURLS" -ge 4 ]; then
+    for IMDBURLS in $(cat "$FILENAME" | tr -c '[:digit:]' '\n' | grep -v "^$"); do
+     if [ "$(echo "$IMDBURLS" | wc -c)" -eq 8 ] || [ "$(echo "$IMDBURLS" | wc -c)" -eq 7 ]; then
       IMDBURL="$IMDBURLS"
       break
      fi
@@ -236,9 +155,14 @@ if [ ! -z "$RECVDARGS" ]; then
     fi
    fi
 
+# apply localized URL path if LOCALURL is set
+   if [ ! -z "$IMDBURL" ] && [ ! -z "$LOCALURL" ]; then
+    IMDBURL="$(imdb_localize_url "$IMDBURL" "$LOCALURL")"
+   fi
+
 # export what we've found
    if [ ! -z "$IMDBURL" ]; then
-    echo "$IMDBURL""|""$PWD" >> $IMDBLOGCHROOTED
+     imdb_queue_lookup "$IMDBURL" "$PWD" "$IMDBLOGCHROOTED"
     if [ ! -z "$DOTIMDB" ]; then
      if [ ! -e "$DOTIMDB" ] || [ -w "$DOTIMDB" ]; then
       echo -n "" > $DOTIMDB
@@ -275,7 +199,14 @@ if [ ! -z "$RECVDARGS" ]; then
      fi
     fi
    fi
-   touch -acmr "$FILENAME" $(pwd) >/dev/null 2>&1
+   # Restore the release dir's original date (undoing the dummy-file creation
+   # bump) so the queue step snapshots the true pre-run date. Only if
+   # FIXDIRTIME is enabled; default is "" - the script does not actively
+   # touch directory timestamps.
+   if [ ! -z "$FIXDIRTIME" ] && [ -f "$DIRDATE_CARRIER" ]; then
+    touch -r "$DIRDATE_CARRIER" "$(pwd)" >/dev/null 2>&1
+    rm -f "$DIRDATE_CARRIER" >/dev/null 2>&1
+   fi
 
 #else
 fi
@@ -288,67 +219,35 @@ if [ ! -z "$RUNCONTINOUS" ] || [ -z "$RECVDARGS" ]; then
 #################################
   PATH=$GLPATHPRE
 
-  a="$(tail -n 5 $GLPRELOG | grep -a "$PRETRIGGER" | tail -n 1)"
-  DIRNAME=""
-  for WORD in $WORDS; do
-   count=0
-   combine=0
-   if [ -z "$a" ]; then
+  a="$(tail -n 5 "$GLPRELOG" | grep "$PRETRIGGER" | tail -n 1)"
+  DIRNAME=$(imdb_extract_pre_dirname "$a" "$PRETRIGGER" "$WORDS" "$SEPARATOR")
+  if [ $? -ne 0 ]; then
     exit 0
-   fi
-   if [ ! -z "$PRETRIGGER" ]; then
-    let WORD=WORD+1
-   fi
-   for b in $a; do
-    if [ -z $(echo $b | grep -a "$PRETRIGGER") ] && [ $count -gt 0 ] || [ -z "$PRETRIGGER" ]; then
-     if [ $combine -eq 1 ]; then
-      c=$c$b
-     else
-      c=$b
-     fi
-     if [ ! -z $(echo "$c" | grep -a "^\"") ]; then
-      combine=1
-     else
-      c=$b
-      let count=count+1
-     fi
-     if [ ! -z $(echo "$c" | grep -a "\"$") ]; then
-      combine=0
-      let count=count+1
-     fi
-     if [ $count -eq $WORD ]; then
-      break
-     fi
-    else
-     if [ "$b" = "$PRETRIGGER" ]; then
-      count=1
-     fi
+  fi
+  if [ -d "$GLROOT$DIRNAME" ]; then
+    FILENAME=$(ls -1 "$GLROOT$DIRNAME" | grep "\.[Nn][Ff][Oo]$" | head -n 1)
+    IMDBURL="$(grep [Ii][Mm][Dd][Bb] "$GLROOT$DIRNAME/$FILENAME" | tr ' ' '\n' | sed -n /[hH][tT][tT][pP][sS]*:[/][/].*[.][iI][mM][dD][bB].*.[0-9]/p | head -n 1 | tr -c -d '[:alnum:]\:./?')"
+    if [ ! -z "$(echo "$IMDBURL" | grep "\.imdb\.")" ]; then
+     IMDBURL="https://www.imdb.com/title/tt""$(echo "$IMDBURL" | sed "s/=/-/g" | sed "s/\.imdb\./=/" | cut -d "=" -f 2 | cut -d "/" -f 2,3 | tr -c -d '[:digit:]')"
     fi
-   done
-   DIRNAME="$DIRNAME""$c"
-  done
-  DIRNAME=$(echo $DIRNAME | sed "s|\"\"|$SEPARATOR|g" | sed "s|\"||g")
-  if [ -d $GLROOT$DIRNAME ]; then
-   FILENAME=$(ls -1 $GLROOT$DIRNAME | grep -a "\.[Nn][Ff][Oo]$" | head -n 1)
-   IMDBURL="$(grep -a [Ii][Mm][Dd][Bb] $GLROOT$DIRNAME/$FILENAME | tr ' ' '\n' | sed -n /[hH][tT][tT][pP][sS]*:[/][/].*[.][iI][mM][dD][bB].*.[0-9]/p | head -n 1 | tr -c -d '[:alnum:]\:./?')"
-   if [ ! -z "$(echo $IMDBURL | grep -a "\.imdb\.")" ]; then
-    IMDBURL="https://www.imdb.com/title/tt""$(echo $IMDBURL | sed "s/=/-/g" | sed "s/.imdb./=/" | cut -d "=" -f 2 | cut -d "/" -f 2,3 | tr -c -d '[:digit:]')"
-   fi
-   if [ ! -z "$IMDBURL" ]; then
-    a="$(tail -n 5 $GLLOG | grep -a "$TRIGGER" | grep -a "$DIRNAME" | tail -n 1)"
+    if [ ! -z "$IMDBURL" ] && [ ! -z "$LOCALURL" ]; then
+     IMDBURL="$(imdb_localize_url "$IMDBURL" "$LOCALURL")"
+    fi
+    if [ ! -z "$IMDBURL" ]; then
+     a="$(tail -n 5 "$GLLOG" | grep "$TRIGGER" | grep "$DIRNAME" | tail -n 1)"
     if [ -z "$a" ]; then
      SEARCHFORURLS=0
      if [ -z "$SCANDIRS" ]; then
       SEARCHFORURLS=1
      fi
      for SCANDIR in $SCANDIRS; do
-      if [ ! -z "$(echo "$DIRNAME" | grep -a "$SCANDIR")" ]; then
+      if [ ! -z "$(echo "$DIRNAME" | grep "$SCANDIR")" ]; then
        SEARCHFORURLS=1
        break
       fi
      done
      if [ ! $SEARCHFORURLS -eq 0 ]; then
-      echo "$IMDBURL""|""$DIRNAME" >> $IMDBLOG
+       imdb_queue_lookup "$IMDBURL" "$DIRNAME" "$IMDBLOG"
      fi
     fi
    fi
@@ -358,7 +257,7 @@ if [ ! -z "$RUNCONTINOUS" ] || [ -z "$RECVDARGS" ]; then
   fi
  fi
 
- if [ ! -e $IMDBLOG ]; then
+ if [ ! -e "$IMDBLOG" ]; then
 
 # Check to see if it's a first-run
 ##################################
@@ -370,7 +269,7 @@ if [ ! -z "$RUNCONTINOUS" ] || [ -z "$RECVDARGS" ]; then
 # The main part.
 ################
 
- if [ -z "$(cat $IMDBLOG)" ]; then
+ if [ -z "$(cat "$IMDBLOG")" ]; then
 
 # No new imdb-info. let's quit.
 ###############################
@@ -379,50 +278,59 @@ if [ ! -z "$RUNCONTINOUS" ] || [ -z "$RECVDARGS" ]; then
 
 # Make sure this script isn't already running.
 ##############################################
- sleep 0.$RANDOM
- IMDBPIDCONTENT="$(head -n2 $IMDBPID | tail -n1)"
- [[ ! -z "$IMDBPIDCONTENT" ]] &&
-   [[ -1 -eq "$IMDBPIDCONTENT" || ! -z $(ps ax | awk '{print $1}' | grep -a -e "^$IMDBPIDCONTENT$") ]] &&
-     exit 0
- echo $$ > $IMDBPID
+ LOCKDIR="${IMDBPID}.lock"
+ if mkdir "$LOCKDIR" 2>/dev/null; then
+   trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+ else
+   IMDBPIDCONTENT="$(head -n2 "$IMDBPID" 2>/dev/null | tail -n1)"
+   if [[ -n "$IMDBPIDCONTENT" ]]; then
+     if [[ "$IMDBPIDCONTENT" -ne -1 ]] && [[ -z "$(ps ax | awk '{print $1}' | grep -e "^$IMDBPIDCONTENT$")" ]]; then
+       rmdir "$LOCKDIR" 2>/dev/null
+       mkdir "$LOCKDIR" 2>/dev/null && trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
+     else
+       exit 0
+     fi
+   fi
+ fi
+ echo $$ > "$IMDBPID"
 
 # Seems like something was put into the log. Let's check it.
 ############################################################
- IMDBFLAGS=$(head -n 1 $TMPRESCANFILE | tr -cd '0-9')
+ IMDBFLAGS=$(head -n 1 "$TMPRESCANFILE" 2>/dev/null | tr -cd '0-9')
  if [ ! -z "$IMDBFLAGS" ]; then
-  if [ $IMDBFLAGS -ge 4 ]; then
+  if [ "$IMDBFLAGS" -ge 4 ]; then
    EXTERNALSCRIPTNAME=""
    let IMDBFLAGS=IMDBFLAGS-4
   fi
-  if [ $IMDBFLAGS -ge 2 ]; then
+  if [ "$IMDBFLAGS" -ge 2 ]; then
    DOTIMDB=""
    INFOTEMPNAME=""
    let IMDBFLAGS=IMDBFLAGS-2
   fi
-  if [ $IMDBFLAGS -ge 1 ]; then
+  if [ "$IMDBFLAGS" -ge 1 ]; then
    USEBOT=""
   fi
  fi
 
- if [ -z "$LANGUAGENUM" ] || [ $LANGUAGENUM -eq 0 ]; then
+ if [ -z "$LANGUAGENUM" ] || [ "$LANGUAGENUM" -eq 0 ]; then
   LANGUAGENUM=99
  fi
- if [ -z "$COUNTRYNUM" ] || [ $COUNTRYNUM -eq 0 ]; then
+ if [ -z "$COUNTRYNUM" ] || [ "$COUNTRYNUM" -eq 0 ]; then
   COUNTRYNUM=99
  fi
- if [ -z "$CERTIFICATIONNUM" ] || [ $CERTIFICATIONNUM -eq 0 ]; then
+ if [ -z "$CERTIFICATIONNUM" ] || [ "$CERTIFICATIONNUM" -eq 0 ]; then
   CERTIFICATIONNUM=99
  fi
- if [ -z "$CASTNUM" ] || [ $CASTNUM -eq 0 ]; then
+ if [ -z "$CASTNUM" ] || [ "$CASTNUM" -eq 0 ]; then
   CASTNUM=99
  fi
- if [ -z "$GENRENUM" ] || [ $GENRENUM -eq 0 ]; then
+ if [ -z "$GENRENUM" ] || [ "$GENRENUM" -eq 0 ]; then
   GENRENUM=99
  fi
- if [ -z "$RUNTIMENUM" ] || [ $RUNTIMENUM -eq 0 ]; then
+ if [ -z "$RUNTIMENUM" ] || [ "$RUNTIMENUM" -eq 0 ]; then
   RUNTIMENUM=99
  fi
- if [ -z "$DIRECTORNUM" ] || [ $DIRECTORNUM -eq 0 ]; then
+ if [ -z "$DIRECTORNUM" ] || [ "$DIRECTORNUM" -eq 0 ]; then
   DIRECTORNUM=99
  fi
 
@@ -431,21 +339,53 @@ if [ ! -z "$RUNCONTINOUS" ] || [ -z "$RECVDARGS" ]; then
   SHOWMETACRITIC="NO"
  fi
 
- while [ ! -z "$(cat $IMDBLOG)" ]; do
-  IMDBLINE="$(grep -a -e "/" "$IMDBLOG" | head -n 1)"
-  grep -a -F -v "$IMDBLINE" "$IMDBLOG" > $TMPFILE
-  cat $TMPFILE > $IMDBLOG
+# Save the effective per-release defaults (after run-level IMDBFLAGS
+# processing) so each queue entry starts fresh. Per-entry branches (API
+# error, missing dir, find /dev/null entries) must not leak state into the
+# next release processed in the same run.
+  DOTIMDB_DEFAULT="$DOTIMDB"
+  USEBOT_DEFAULT="$USEBOT"
+  EXTERNALSCRIPTNAME_DEFAULT="$EXTERNALSCRIPTNAME"
+  INFOTEMPNAME_DEFAULT="$INFOTEMPNAME"
+  BOTONELINE_DEFAULT="$BOTONELINE"
+  TRIGGER_DEFAULT="$TRIGGER"
+  LOGFORMAT_DEFAULT="$LOGFORMAT"
+  MYOWNFORMAT_DEFAULT="$MYOWNFORMAT"
+  MYOWNEMPTY_DEFAULT="$MYOWNEMPTY"
+  GLLOG_DEFAULT="$GLLOG"
+  TAGPLOT_DEFAULT="$TAGPLOT"
+  BOTHEAD_DEFAULT="$BOTHEAD"
+
+ while [ ! -z "$(cat "$IMDBLOG")" ]; do
+  IMDBLINE="$(grep -e "/" "$IMDBLOG" | head -n 1)"
+  grep -F -v "$IMDBLINE" "$IMDBLOG" > "$TMPFILE"
+  cat "$TMPFILE" > "$IMDBLOG"
+  DOTIMDB="$DOTIMDB_DEFAULT"
+  USEBOT="$USEBOT_DEFAULT"
+  EXTERNALSCRIPTNAME="$EXTERNALSCRIPTNAME_DEFAULT"
+  INFOTEMPNAME="$INFOTEMPNAME_DEFAULT"
+  BOTONELINE="$BOTONELINE_DEFAULT"
+  TRIGGER="$TRIGGER_DEFAULT"
+  LOGFORMAT="$LOGFORMAT_DEFAULT"
+  MYOWNFORMAT="$MYOWNFORMAT_DEFAULT"
+  MYOWNEMPTY="$MYOWNEMPTY_DEFAULT"
+  GLLOG="$GLLOG_DEFAULT"
+  TAGPLOT="$TAGPLOT_DEFAULT"
+  BOTHEAD="$BOTHEAD_DEFAULT"
   ISLIMITED=""
   BUSINESS=""
   BUSINESSSHORT=""
   PREMIERE=""
   LIMITED=""
   EXEMPTED=""
-  IMDBURL="$(echo $IMDBLINE | cut -d "|" -f 1)"
-  IMDBLNK="$(echo $IMDBLINE | cut -d "|" -f 2)"
-  IMDBDST="$(echo $IMDBLINE | cut -d "|" -f 3)"
+  IMDBURL="$(echo "$IMDBLINE" | cut -d "|" -f 1)"
+  if [ ! -z "$IMDBURL" ] && [ ! -z "$LOCALURL" ]; then
+   IMDBURL="$(imdb_localize_url "$IMDBURL" "$LOCALURL")"
+  fi
+  IMDBLNK="$(echo "$IMDBLINE" | cut -d "|" -f 2)"
+  IMDBDST="$(echo "$IMDBLINE" | cut -d "|" -f 3)"
   DEBUGCOUNT=1
-  if [ ! -z $DEBUG ]; then
+  if [ ! -z "$DEBUG" ]; then
    echo "$DEBUGCOUNT : DOTIMDB = '$DOTIMDB'"
    echo "$DEBUGCOUNT : USEBOT = '$USEBOT'"
   fi
@@ -464,7 +404,7 @@ if [ ! -z "$RUNCONTINOUS" ] || [ -z "$RECVDARGS" ]; then
    LOGFORMAT="$FINDLOGFORMAT"
    MYOWNFORMAT="$FINDMYOWNFORMAT"
    MYOWNEMPTY="$FINDMYOWNEMPTY"
-   if [ ! -z "$PSXCFINDLOG" ] && [ -w $PSXCFINDLOG ]; then
+   if [ ! -z "$PSXCFINDLOG" ] && [ -w "$PSXCFINDLOG" ]; then
     GLLOG=$PSXCFINDLOG
    fi
   else
@@ -474,12 +414,12 @@ if [ ! -z "$RUNCONTINOUS" ] || [ -z "$RECVDARGS" ]; then
    INFOTEMPNAME=""
   fi
   DEBUGCOUNT=2
-  if [ ! -z $DEBUG ]; then
+  if [ ! -z "$DEBUG" ]; then
    echo "$DEBUGCOUNT : DOTIMDB = '$DOTIMDB'"
    echo "$DEBUGCOUNT : USEBOT = '$USEBOT'"  
   fi
   for EXEMPT in $BOTEXEMPT; do
-   if [ ! -z $(echo "$IMDBLKL" | grep -a "$EXEMPT") ]; then
+   if [ ! -z "$(echo "$IMDBLKL" | grep "$EXEMPT")" ]; then
     USEBOT=""
     EXEMPTED="ON"
    fi
@@ -490,40 +430,48 @@ if [ ! -z "$RUNCONTINOUS" ] || [ -z "$RECVDARGS" ]; then
    BOTHEAD=""
   fi
   DEBUGCOUNT=3
-  if [ ! -z $DEBUG ]; then
+  if [ ! -z "$DEBUG" ]; then
    echo "$DEBUGCOUNT : DOTIMDB = '$DOTIMDB'"
    echo "$DEBUGCOUNT : USEBOT = '$USEBOT'"  
   fi
-  if [ ! -z $(grep -a "$IMDBURL" "$IMDBURLLOG") ] || [ ! -z $EXEMPTED ]; then
+  if [ ! -z "$(grep "$IMDBURL" "$IMDBURLLOG")" ] || [ ! -z "$EXEMPTED" ]; then
    if [ ! "$IMDBLKL" = "/dev/null" ]; then
     USEBOT=""
    fi
   else
    if [ ! "$IMDBLKL" = "/dev/null" ]; then
-    echo "$IMDBURL" >> $IMDBURLLOG
-    tail -n $KEEPURLS $IMDBURLLOG > $TMPFILE
-    cat $TMPFILE > $IMDBURLLOG
-    echo -n "" > $TMPFILE
+    echo "$IMDBURL" >> "$IMDBURLLOG"
+    tail -n "$KEEPURLS" "$IMDBURLLOG" > "$TMPFILE"
+    cat "$TMPFILE" > "$IMDBURLLOG"
+    echo -n "" > "$TMPFILE"
    fi
   fi
   DEBUGCOUNT=4
-  if [ ! -z $DEBUG ]; then
+  if [ ! -z "$DEBUG" ]; then
    echo "$DEBUGCOUNT : DOTIMDB = '$DOTIMDB'"
    echo "$DEBUGCOUNT : USEBOT = '$USEBOT'"
   fi
 
+# Snapshot the release dir's original date so it can be restored after
+# writing the info files (FIXDIRTIME gated). Works chrooted and on host.
+  RELDIR="$GLROOT$IMDBLKL"
+  [ -d "$RELDIR" ] || RELDIR="$IMDBLKL"
+  if [ ! -z "$FIXDIRTIME" ] && [ -d "$RELDIR" ]; then
+   touch -r "$RELDIR" "$DIRDATE_CARRIER" >/dev/null 2>&1
+  fi
+
 # grab info from GraphQL API
 #############################
-  IMDB_ID=$(extract_imdb_id "$IMDBURL")
+  IMDB_ID=$(imdb_extract_id "$IMDBURL")
   OUTPUTOK=""
 
   if [ -z "$IMDB_ID" ]; then
-    if [ ! -z $DEBUG ]; then
+    if [ ! -z "$DEBUG" ]; then
       echo "DEBUG: Could not extract IMDb ID from $IMDBURL"
     fi
   else
     TITLE_QUERY="query{title(id:\"${IMDB_ID}\"){titleText{text}originalTitleText{text}releaseYear{year}titleType{text}genres{genres{text}}ratingsSummary{aggregateRating voteCount}plot{plotText{plainText}}runtime{seconds}directors:credits(first:${DIRECTORNUM},filter:{categories:[\"director\"]}){edges{node{name{nameText{text}}}}}stars:credits(first:${CASTNUM},filter:{categories:[\"actor\",\"actress\"]}){edges{node{name{nameText{text}}}}}countriesOfOrigin{countries{id}}spokenLanguages{spokenLanguages{id}}akas(first:50){edges{node{text country{id}}}}taglines(first:1){edges{node{text}}}certificates(first:50){edges{node{rating country{id}}}}releaseDates(first:100){edges{node{day month year country{id}attributes{text}}}}productionBudget{budget{amount currency}}worldwide:lifetimeGross(boxOfficeArea:WORLDWIDE){total{amount currency}}openingWeekendGross(boxOfficeArea:DOMESTIC){gross{total{amount currency}}}metacritic{metascore{score reviewCount}}}}"
-    API_RESPONSE=$(graphql_request "$TITLE_QUERY")
+    API_RESPONSE=$(imdb_request "$TITLE_QUERY")
 
     if [ $? -eq 0 ] && [ -n "$API_RESPONSE" ]; then
       TITLE=$($JQ_BIN -r '.data.title.titleText.text // empty' <<< "$API_RESPONSE")
@@ -548,45 +496,16 @@ if [ ! -z "$RUNCONTINOUS" ] || [ -z "$RECVDARGS" ]; then
         # Extract language from release name and look up localized AKA title
         LOCALETITLE=""
         if [ -z "$USEORIGTITLE" ]; then
-          RELLANG=$(echo "$IMDBDIR" | tr '.\-_' '\n' | tr 'A-Z' 'a-z' | grep -axF -e chinese -e dutch -e english -e finnish -e french -e german -e greek -e hebrew -e hungarian -e italian -e japanese -e korean -e norwegian -e polish -e portuguese -e romanian -e russian -e spanish -e swedish -e turkish -e nl -e fr -e de -e it -e es -e en -e danish -e icelandic -e czech | head -n 1)
-          if [ ! -z "$RELLANG" ]; then
-            case "$RELLANG" in
-              chinese)    AKA_CC="CN" ;;
-              dutch)      AKA_CC="NL" ;;
-              english)    AKA_CC="GB" ;;
-              finnish)    AKA_CC="FI" ;;
-              french)     AKA_CC="FR" ;;
-              german)     AKA_CC="DE" ;;
-              greek)      AKA_CC="GR" ;;
-              hebrew)     AKA_CC="IL" ;;
-              hungarian)  AKA_CC="HU" ;;
-              italian)    AKA_CC="IT" ;;
-              japanese)   AKA_CC="JP" ;;
-              korean)     AKA_CC="KR" ;;
-              norwegian)  AKA_CC="NO" ;;
-              polish)     AKA_CC="PL" ;;
-              portuguese) AKA_CC="PT" ;;
-              romanian)   AKA_CC="RO" ;;
-              russian)    AKA_CC="RU" ;;
-              spanish)    AKA_CC="ES" ;;
-              swedish)    AKA_CC="SE" ;;
-              turkish)    AKA_CC="TR" ;;
-              nl)         AKA_CC="NL" ;;
-              fr)         AKA_CC="FR" ;;
-              de)         AKA_CC="DE" ;;
-              it)         AKA_CC="IT" ;;
-              es)         AKA_CC="ES" ;;
-              en)         AKA_CC="GB" ;;
-              danish)     AKA_CC="DK" ;;
-              icelandic)  AKA_CC="IS" ;;
-              czech)      AKA_CC="CZ" ;;
-              *)          AKA_CC="" ;;
-            esac
-            if [ ! -z "$AKA_CC" ]; then
-              LOCALETITLE=$($JQ_BIN -r --arg cc "$AKA_CC" '(.data.title.akas.edges // []) | map(select(.node.country.id == $cc)) | .[0].node.text // empty' <<< "$API_RESPONSE")
-              if [ -z "$LOCALETITLE" ] && [ ! -z $DEBUG ]; then
-                echo "DEBUG: No AKA found for $IMDB_ID in country $AKA_CC"
-              fi
+          RELLANG=$(echo "$IMDBDIR" | tr '.\-_' '\n' | tr 'A-Z' 'a-z' | grep -xF -e chinese -e dutch -e english -e finnish -e french -e german -e greek -e hebrew -e hungarian -e italian -e japanese -e korean -e norwegian -e polish -e portuguese -e romanian -e russian -e spanish -e swedish -e turkish -e nl -e fr -e de -e it -e es -e en -e danish -e icelandic -e czech | head -n 1)
+          if [ -n "$RELLANG" ] && [ -n "${LANG_TO_COUNTRY[$RELLANG]:-}" ]; then
+            AKA_CC="${LANG_TO_COUNTRY[$RELLANG]}"
+          else
+            AKA_CC=""
+          fi
+          if [ ! -z "$AKA_CC" ]; then
+            LOCALETITLE=$($JQ_BIN -r --arg cc "$AKA_CC" '(.data.title.akas.edges // []) | map(select(.node.country.id == $cc)) | .[0].node.text // empty' <<< "$API_RESPONSE")
+            if [ -z "$LOCALETITLE" ] && [ ! -z $DEBUG ]; then
+              echo "DEBUG: No AKA found for $IMDB_ID in country $AKA_CC"
             fi
           fi
         fi
@@ -663,7 +582,7 @@ if [ ! -z "$RUNCONTINOUS" ] || [ -z "$RECVDARGS" ]; then
         RUNTIMECLEAN="$RUNTIME"
 
         DIRECTORCLEAN=$($JQ_BIN -r '(.data.title.directors.edges // []) | .[0:'"$DIRECTORNUM"'] | map(.node.name.nameText.text) | join("/")' <<< "$API_RESPONSE")
-        DIRECTOR="Directed by..: $DIRECTORCLEAN"
+        DIRECTOR="$DIRECTORCLEAN"
 
         CASTCLEAN=$($JQ_BIN -r '(.data.title.stars.edges // []) | .[0:'"$CASTNUM"'] | map(.node.name.nameText.text) | join(", ")' <<< "$API_RESPONSE")
         CAST="$CASTCLEAN"
@@ -728,14 +647,14 @@ if [ ! -z "$RUNCONTINOUS" ] || [ -z "$RECVDARGS" ]; then
     if [ -n "$UNSUPPORTED_TYPE" ]; then
       ERROR_MSG="iMDB type '$TITLETYPE' not fully supported (limited data available)"
     fi
-    if [ ! -z "$(echo $IMDBLKL | grep -a -e "/dev/null")" ]; then
-      if [ -z "$LOGFORMAT" ]; then
-        echo "$DATE $TRIGGER \"$IMDBLKL\" \"$ERROR_MSG\" \"$IMDBDST\"" >> $GLLOG
-      elif [ "$LOGFORMAT" = "MYOWN" ]; then
-        echo "$DATE $TRIGGER \"$IMDBLKL\" \"$ERROR_MSG\" \"$IMDBDST\"" >> $GLLOG
-      else
-        echo "$DATE $TRIGGER \"$IMDBLKL\" \"\" \"$ERROR_MSG\"" >> $GLLOG
-      fi
+    if [ ! -z "$(echo "$IMDBLKL" | grep -e "/dev/null")" ]; then
+     if [ -z "$LOGFORMAT" ]; then
+        imdb_write_log "$ERROR_MSG"
+       elif [ "$LOGFORMAT" = "MYOWN" ]; then
+        imdb_write_log "$ERROR_MSG"
+       else
+        echo "$DATE $TRIGGER \"$IMDBLKL\" \"\" \"$ERROR_MSG\"" >> "$GLLOG"
+       fi
     else
       rm -f "$GLROOT/$IMDBLKL/$INFOTEMPNAME" >/dev/null 2>&1
       rmdir "$GLROOT/$IMDBLKL/$INFOTEMPNAME" >/dev/null 2>&1
@@ -748,16 +667,16 @@ if [ ! -z "$RUNCONTINOUS" ] || [ -z "$RECVDARGS" ]; then
 
     if [ ! -z "$USEBOM" ]; then
       BOMURL="https://www.boxofficemojo.com/title/${IMDB_ID}/"
-      BOM_RESPONSE=$(curl $CURLFLAGS -s -A "$USERAGENT" --connect-timeout $IMDBAPI_TIMEOUT "$BOMURL" 2>/dev/null)
+      BOM_RESPONSE=$(curl "$CURLFLAGS" -s -A "$USERAGENT" --connect-timeout "$IMDBAPI_TIMEOUT" "$BOMURL" 2>/dev/null)
       if [ -n "$BOM_RESPONSE" ]; then
         BOMRELEASEGROUP=$(echo "$BOM_RESPONSE" | sed -n -E 's|.*<option value="(/releasegroup/gr[0-9]+/)">Original Release</option>.*|\1|p')
         if [ -n "$BOMRELEASEGROUP" ]; then
           BOMURLRELEASEGROUP="https://www.boxofficemojo.com${BOMRELEASEGROUP}"
-          BOM_RELEASE=$(curl $CURLFLAGS -s -A "$USERAGENT" --connect-timeout $IMDBAPI_TIMEOUT "$BOMURLRELEASEGROUP" 2>/dev/null)
+          BOM_RELEASE=$(curl "$CURLFLAGS" -s -A "$USERAGENT" --connect-timeout "$IMDBAPI_TIMEOUT" "$BOMURLRELEASEGROUP" 2>/dev/null)
           BOMRELEASE=$(echo "$BOM_RELEASE" | sed -n -E 's|.*<a class="a-link-normal" href="(/release/rl[0-9]+/)[^\"]*">Domestic[^\n]*</a>.*|\1|p' | head -1)
           if [ -n "$BOMRELEASE" ]; then
             BOMURLRELEASE="https://www.boxofficemojo.com${BOMRELEASE}"
-            BOM_DETAIL=$(curl $CURLFLAGS -s -A "$USERAGENT" --connect-timeout $IMDBAPI_TIMEOUT "$BOMURLRELEASE" 2>/dev/null)
+            BOM_DETAIL=$(curl "$CURLFLAGS" -s -A "$USERAGENT" --connect-timeout "$IMDBAPI_TIMEOUT" "$BOMURLRELEASE" 2>/dev/null)
             if [ ! -z "$USEWIDEST" ]; then
               BUSINESSSCREENS=$(echo "$BOM_DETAIL" | sed -n -E 's|.*<div[^>]*><span>Widest Release</span><span>([0-9,]+) theaters</span></div>.*|\1|p' | head -1 | tr -d ',')
             else
@@ -776,7 +695,7 @@ if [ ! -z "$RUNCONTINOUS" ] || [ -z "$RECVDARGS" ]; then
       fi
     fi
    if [ ! -z "$IMDBHEAD" ]; then
-    BOTHEAD=$(echo $BOTHEADORIG | sed "s/RELEASENAME/$BOLD$IMDBDIR$BOLD/")
+    BOTHEAD=$(echo "$BOTHEAD" | sed "s/RELEASENAME/$BOLD$IMDBDIR$BOLD/")
    fi
    if [ ! -z $DEBUG ]; then
     DEBUGCOUNT=5
@@ -797,9 +716,6 @@ if [ ! -z "$RUNCONTINOUS" ] || [ -z "$RECVDARGS" ]; then
 # Time to put stuff out so the bot can read it.
 ###############################################
 
-    if [ ! -z "$LOCALURL" ]; then
-     IMDBURL="$(echo $IMDBURL | sed "s|/www.|/$LOCALURL.|g" | tr 'A-Z' 'a-z')"
-    fi
     HEADTMP="Title........: $BOLD$TITLE$BOLD"
     if [ ! -z "$COUNTRY" ]; then
      HEADTMP="$HEADTMP / $COUNTRY"
@@ -809,59 +725,59 @@ if [ ! -z "$RUNCONTINOUS" ] || [ -z "$RECVDARGS" ]; then
     fi
     HEAD=$(echo "$HEADTMP" | sed "s/Country......: //" | sed "s/Language.....: //" | tr -s ' ')
     if [ ! -z "$BOTHEAD" ]; then
-     echo "$DATE $TRIGGER \"$IMDBLKL\" \"$BOTHEAD\" \"$IMDBDST\"" >> $GLLOG
+     imdb_write_log "$BOTHEAD"
     fi
     if [ ! -z "$HEAD" ] && [ -z "$BOTONELINE" ]; then
-     echo "$DATE $TRIGGER \"$IMDBLKL\" \"$HEAD\" \"$IMDBDST\"" >> $GLLOG
+     imdb_write_log "$HEAD"
     fi
     if [ -z "$BOTONELINE" ]; then
-     echo "$DATE $TRIGGER \"$IMDBLKL\" \"IMDb Link....: $IMDBURL\" \"$IMDBDST\"" >> $GLLOG
+     imdb_write_log "IMDb Link....: $IMDBURL"
     fi
     if [ ! -z "$DIRECTOR" ] && [ -z "$BOTONELINE" ]; then
-     echo "$DATE $TRIGGER \"$IMDBLKL\" \"$DIRECTOR\" \"$IMDBDST\"" >> $GLLOG
+     imdb_write_log "$DIRECTOR"
     fi
     if [ ! -z "$GENRE" ] && [ -z "$BOTONELINE" ]; then
-     echo "$DATE $TRIGGER \"$IMDBLKL\" \"$GENRE\" \"$IMDBDST\"" >> $GLLOG
+     imdb_write_log "$GENRE"
     fi
     if [ ! -z "$RATING" ] && [ -z "$BOTONELINE" ]; then
-     echo "$DATE $TRIGGER \"$IMDBLKL\" \"$RATING\" \"$IMDBDST\"" >> $GLLOG
+     imdb_write_log "$RATING"
     fi
     if [ ! -z "$SHOWMETACRITIC" ] && [ ! -z "$METASCORE" ] && [ -z "$BOTONELINE" ]; then
-     echo "$DATE $TRIGGER \"$IMDBLKL\" \"Metacritic..: $METASCORE/100 ($METAREVIEWS reviews)\" \"$IMDBDST\"" >> $GLLOG
+     imdb_write_log "Metacritic..: $METASCORE/100 ($METAREVIEWS reviews)"
     fi
     if [ ! -z "$SHOWSTAR" ] && [ -z "$BOTONELINE" ] && [ ! -z "$CASTLEADNAME" ]; then
-     echo "$DATE $TRIGGER \"$IMDBLKL\" \"Starring.....: $CASTLEADNAME as $CASTLEADCHAR\" \"$IMDBDST\"" >> $GLLOG
+     imdb_write_log "Starring.....: $CASTLEADNAME as $CASTLEADCHAR"
     fi
     if [ ! -z "$RUNTIME" ] && [ -z "$BOTONELINE" ]; then
-     echo "$DATE $TRIGGER \"$IMDBLKL\" \"$RUNTIME\" \"$IMDBDST\"" >> $GLLOG
+     imdb_write_log "$RUNTIME"
     fi
     if [ ! -z "$BUSINESSSHORT" ] && [ -z "$BOTONELINE" ]; then
-     echo "$DATE $TRIGGER \"$IMDBLKL\" \"Opening Stats: $BUSINESSSHORT\" \"$IMDBDST\"" | tr '[=$=]' '¤' | sed "s|¤|USD|g" >> $GLLOG
+     imdb_write_log "Opening Stats: $BUSINESSSHORT" --usd
     fi
     if [ ! -z "$PREMIERE" ] && [ -z "$BOTONELINE" ]; then
-     echo "$DATE $TRIGGER \"$IMDBLKL\" \"Premiere Date: $PREMIERE\" \"$IMDBDST\"" >> $GLLOG
+     imdb_write_log "Premiere Date: $PREMIERE"
     fi
     if [ ! -z "$LIMITED" ] && [ -z "$BOTONELINE" ]; then
-     echo "$DATE $TRIGGER \"$IMDBLKL\" \"Limited Date.: $LIMITED\" \"$IMDBDST\"" >> $GLLOG
+     imdb_write_log "Limited Date.: $LIMITED"
     fi
     if [ ! -z "$TAGLINE" ] && [ ! -z "$PLOT" ] && [ -z "$BOTONELINE" ]; then
      if [ "$TAGPLOT" = "TAG" ] || [ -z "$TAGPLOT" ] ; then
-      echo "$DATE $TRIGGER \"$IMDBLKL\" \"$TAGLINE\" \"$IMDBDST\"" >> $GLLOG
+      imdb_write_log "$TAGLINE"
      fi
      if [ "$TAGPLOT" = "PLOT" ] || [ -z "$TAGPLOT" ]; then
-      echo "$DATE $TRIGGER \"$IMDBLKL\" \"$PLOT\" \"$IMDBDST\"" >> $GLLOG
+      imdb_write_log "$PLOT"
      fi
     elif [ ! -z "$TAGLINE" ] && [ ! "$TAGPLOT" = "NONE" ] && [ -z "$BOTONELINE" ]; then
-     echo "$DATE $TRIGGER \"$IMDBLKL\" \"$TAGLINE\" \"$IMDBDST\"" >> $GLLOG
+     imdb_write_log "$TAGLINE"
     elif [ ! -z "$PLOT" ] && [ ! "$TAGPLOT" = "NONE" ] && [ -z "$BOTONELINE" ]; then
-     echo "$DATE $TRIGGER \"$IMDBLKL\" \"$PLOT\" \"$IMDBDST\"" >> $GLLOG
+     imdb_write_log "$PLOT"
     fi
     if [ ! -z "$SHOWCOMMENTSHORT" ] && [ ! "$COMMENTSHORT" = "User Reviews:" ] && [ -z "$BOTONELINE" ]; then
-     echo "$DATE $TRIGGER \"$IMDBLKL\" \"$COMMENTSHORT\" \"$IMDBDST\"" >> $GLLOG
+     imdb_write_log "$COMMENTSHORT"
     fi
     if  [ ! -z "$BOTONELINE" ]; then
      if [ -z "$LOGFORMAT" ]; then
-      echo "$DATE $TRIGGER \"$IMDBLKL\" \"$ONELINE\" \"$IMDBDST\"" >> $GLLOG
+      imdb_write_log "$ONELINE"
      elif [ "$LOGFORMAT" = "MYOWN" ]; then
 #      NEWLINE="|"
       MYOWNPAIRS="%imdbdirname|IMDBDIR %imdburl|IMDBURL %imdbtitle|TITLE %imdbgenre|GENRECLEAN %imdbrating|RATINGCLEAN %imdbcountry|COUNTRYCLEAN %imdblanguage|LANGUAGECLEAN %imdbcertification|CERTCLEAN %imdbruntime|RUNTIMECLEAN %imdbdirector|DIRECTORCLEAN %imdbbusinessdata|BUSINESSSHORT %imdbpremiereinfo|PREMIERE %imdblimitedinfo|LIMITED %imdbvotes|RATINGVOTES %imdbscore|RATINGSCORE %imdbname|TITLENAME %imdbyear|TITLEYEAR %imdbnumscreens|BUSINESSSCREENS %imdbislimited|ISLIMITED %imdbcastleadname|CASTLEADNAME %imdbcastleadchar|CASTLEADCHAR %imdbtagline|TAGLINECLEAN %imdbplot|PLOTCLEAN %imdbbar|RATINGBAR %imdbcasting|CASTCLEAN %imdbcommentshort|COMMENTSHORTCLEAN %imdbmetacritic|METACLEAN %newline|NEWLINE %bold|BOLD"
@@ -879,19 +795,19 @@ if [ ! -z "$RUNCONTINOUS" ] || [ -z "$RECVDARGS" ]; then
       if [ "$IMDBSPLITLINES" = "YES" ]; then
        LINE1="${MYOWNFORMAT1%%\\n*}"
        LINE2="${MYOWNFORMAT1#*\\n}"
-       if [ "$LINE1" != "$LINE2" ]; then
-        echo "$DATE $TRIGGER \"$IMDBLKL\" \"$LINE1\" \"$IMDBDST\"" | tr '[=$=]' '¤' | sed "s|¤|USD|g" >> $GLLOG
-        CURTRIG="$TRIGGER"
-        [ -n "$IMDBSPLITTRIG" ] && CURTRIG="$IMDBSPLITTRIG"
-        echo "$DATE $CURTRIG \"$IMDBLKL\" \"$LINE2\" \"$IMDBDST\"" | tr '[=$=]' '¤' | sed "s|¤|USD|g" >> $GLLOG
+        if [ "$LINE1" != "$LINE2" ]; then
+         imdb_write_log "$LINE1" --usd
+         CURTRIG="$TRIGGER"
+         [ -n "$IMDBSPLITTRIG" ] && CURTRIG="$IMDBSPLITTRIG"
+         imdb_write_log "$LINE2" --usd "$CURTRIG"
        else
-        echo "$DATE $TRIGGER \"$IMDBLKL\" \"${MYOWNFORMAT1}\" \"$IMDBDST\"" | tr '[=$=]' '¤' | sed "s|¤|USD|g" >> $GLLOG
+        imdb_write_log "${MYOWNFORMAT1}" --usd
        fi
       else
-       echo "$DATE $TRIGGER \"$IMDBLKL\" \"${MYOWNFORMAT1}\" \"$IMDBDST\"" | tr '[=$=]' '¤' | sed "s|¤|USD|g" >> $GLLOG
+       imdb_write_log "${MYOWNFORMAT1}" --usd
       fi
      else
-      echo "$DATE $TRIGGER \"$IMDBLKL\" \"$IMDBDIR\" \"$IMDBURL\" \"$TITLE\" \"$GENRECLEAN\" \"$RATINGCLEAN\" \"$COUNTRYCLEAN\" \"$LANGUAGECLEAN\" \"$CERTCLEAN\" \"$RUNTIMECLEAN\" \"$DIRECTORCLEAN\" \"$BUSINESSSHORT\" \"$PREMIERE\" \"$LIMITED\" \"$RATINGVOTES\" \"$RATINGSCORE\" \"$TITLENAME\" \"$TITLEYEAR\" \"$BUSINESSSCREENS\" \"$ISLIMITED\" \"$CASTLEADNAME\" \"$CASTLEADCHAR\" \"$TAGLINECLEAN\" \"$PLOTCLEAN\" \"$RATINGBAR\" \"$CASTCLEAN\" \"$COMMENTSHORTCLEAN\" \"$METACLEAN\" \"$IMDBDST\"" | tr '[=$=]' '¤' | sed "s|¤|USD|g" >> $GLLOG
+      imdb_write_log "$IMDBDIR\" \"$IMDBURL\" \"$TITLE\" \"$GENRECLEAN\" \"$RATINGCLEAN\" \"$COUNTRYCLEAN\" \"$LANGUAGECLEAN\" \"$CERTCLEAN\" \"$RUNTIMECLEAN\" \"$DIRECTORCLEAN\" \"$BUSINESSSHORT\" \"$PREMIERE\" \"$LIMITED\" \"$RATINGVOTES\" \"$RATINGSCORE\" \"$TITLENAME\" \"$TITLEYEAR\" \"$BUSINESSSCREENS\" \"$ISLIMITED\" \"$CASTLEADNAME\" \"$CASTLEADCHAR\" \"$TAGLINECLEAN\" \"$PLOTCLEAN\" \"$RATINGBAR\" \"$CASTCLEAN\" \"$COMMENTSHORTCLEAN\" \"$METACLEAN" --usd
      fi
     fi
    fi
@@ -900,101 +816,101 @@ if [ ! -z "$RUNCONTINOUS" ] || [ -z "$RECVDARGS" ]; then
 # Echo stuff to the .imdb file
 ##############################
 
-    echo -e "$IMDBHEAD" > "$IMDBLNK"
-    OWNER=$(ls -1nl "$GLROOT$IMDBLKL" | tail -n 1 | { read junk junk owner group junk; echo $owner:$group; };)
-    echo "Title........: $TITLE" | fold -s -w $IMDBWIDTH | head -n 1 >> "$IMDBLNK"
+    printf "%b\n" "$IMDBHEAD" > "$IMDBLNK"
+    OWNER=$(ls -1nl "$GLROOT$IMDBLKL" | tail -n 1 | { read junk junk owner group junk; echo "$owner:$group"; };)
+    echo "Title........: $TITLE" | fold -s -w "$IMDBWIDTH" | head -n 1 >> "$IMDBLNK"
     echo "-" >> "$IMDBLNK"
     echo "IMDb Link....: $IMDBURL" | head -n 1 >> "$IMDBLNK"
     if [ ! -z "$DIRECTOR" ]; then
-     echo "$DIRECTOR" | fold -s -w $IMDBWIDTH | head -n 1 >> "$IMDBLNK"
+     echo "$DIRECTOR" | fold -s -w "$IMDBWIDTH" | head -n 1 >> "$IMDBLNK"
     fi
     if [ ! -z "$GENRE" ]; then
-     echo "$GENRE" | fold -s -w $IMDBWIDTH | head -n 1 >> "$IMDBLNK"
+     echo "$GENRE" | fold -s -w "$IMDBWIDTH" | head -n 1 >> "$IMDBLNK"
     fi
     if [ ! -z "$RATING" ]; then
-     echo "$RATING" | fold -s -w $IMDBWIDTH | head -n 1 >> "$IMDBLNK"
+     echo "$RATING" | fold -s -w "$IMDBWIDTH" | head -n 1 >> "$IMDBLNK"
     fi
     if [ ! -z "$SHOWMETACRITIC" ] && [ ! -z "$METASCORE" ]; then
-     echo "Metacritic..: $METASCORE/100 ($METAREVIEWS reviews)" | fold -s -w $IMDBWIDTH | head -n 1 >> "$IMDBLNK"
+     echo "Metacritic..: $METASCORE/100 ($METAREVIEWS reviews)" | fold -s -w "$IMDBWIDTH" | head -n 1 >> "$IMDBLNK"
     fi
     if [ ! -z "$TAGLINE" ]; then
-     echo "$TAGLINE" | fold -s -w $IMDBWIDTH >> "$IMDBLNK"
+     echo "$TAGLINE" | fold -s -w "$IMDBWIDTH" >> "$IMDBLNK"
     fi
     echo "-" >> "$IMDBLNK"
     if [ ! -z "$COUNTRY" ]; then
-     echo "$COUNTRY" | fold -s -w $IMDBWIDTH | head -n 1 >> "$IMDBLNK"
+     echo "$COUNTRY" | fold -s -w "$IMDBWIDTH" | head -n 1 >> "$IMDBLNK"
     fi
     if [ ! -z "$LANGUAGE" ]; then
-     echo "$LANGUAGE" | fold -s -w $IMDBWIDTH | head -n 1 >> "$IMDBLNK"
+     echo "$LANGUAGE" | fold -s -w "$IMDBWIDTH" | head -n 1 >> "$IMDBLNK"
     fi
     if [ ! -z "$CERT" ]; then
-     echo "Certification:[[SPACE]]$CERT" | fold -s -w $IMDBWIDTH | head -n 1 | sed 's/\[\[SPACE\]\]/ /' >> "$IMDBLNK"
+     echo "Certification:[[SPACE]]$CERT" | fold -s -w "$IMDBWIDTH" | head -n 1 | sed 's/\[\[SPACE\]\]/ /' >> "$IMDBLNK"
     fi
     if [ ! -z "$PREMIERE" ]; then
-     echo "Premiere Date: $PREMIERE" | fold -s -w $IMDBWIDTH | head -n 1 >> "$IMDBLNK"
+     echo "Premiere Date: $PREMIERE" | fold -s -w "$IMDBWIDTH" | head -n 1 >> "$IMDBLNK"
     fi
     if [ ! -z "$LIMITED" ]; then
-     echo "Limited Date.: $LIMITED" | fold -s -w $IMDBWIDTH | head -n 1 >> "$IMDBLNK"
+     echo "Limited Date.: $LIMITED" | fold -s -w "$IMDBWIDTH" | head -n 1 >> "$IMDBLNK"
     fi
     if [ ! -z "$RUNTIME" ]; then
-     echo "Runtime......: $RUNTIME" | fold -s -w $IMDBWIDTH | head -n 1 >> "$IMDBLNK"
+     echo "Runtime......: $RUNTIME" | fold -s -w "$IMDBWIDTH" | head -n 1 >> "$IMDBLNK"
     fi
     if [ ! -z "$CAST" ]; then
      echo "-" >> "$IMDBLNK"
      echo "Credited Cast:" >> "$IMDBLNK"
-     echo "$CAST" | fold -s -w $IMDBWIDTH >> "$IMDBLNK"
+     echo "$CAST" | fold -s -w "$IMDBWIDTH" >> "$IMDBLNK"
     fi
     if [ ! -z "$BUSINESS" ]; then
      echo "-" >> "$IMDBLNK"
      echo "Business Data on Opening Weekend:" >> "$IMDBLNK"
-     echo "$BUSINESS" | fold -s -w $IMDBWIDTH >> "$IMDBLNK"
+     echo "$BUSINESS" | fold -s -w "$IMDBWIDTH" >> "$IMDBLNK"
     fi
     if [ ! -z "$PLOT" ]; then
      echo "-" >> "$IMDBLNK"
-     #echo "$PLOT" | fold -s -w $IMDBWIDTH >> "$IMDBLNK"
-     echo "$PLOT" | sed s/"$NEWLINE"//g | fold -s -w $IMDBWIDTH >> "$IMDBLNK"
+     #echo "$PLOT" | fold -s -w "$IMDBWIDTH" >> "$IMDBLNK"
+     echo "$PLOT" | sed s/"$NEWLINE"//g | fold -s -w "$IMDBWIDTH" >> "$IMDBLNK"
     fi
     if [ ! -z "$SHOWCOMMENT" ] && [ ! -z "$COMMENT" ]; then
      echo "---" >> "$IMDBLNK"
      echo "User Review:" >> "$IMDBLNK"
-     echo "$COMMENT" | sed "s/^\ *//g" | sed "s/\ *$//g" | tr -s ' ' | fold -s -w $IMDBWIDTH >> "$IMDBLNK"
+     echo "$COMMENT" | sed "s/^\ *//g" | sed "s/\ *$//g" | tr -s ' ' | fold -s -w "$IMDBWIDTH" >> "$IMDBLNK"
     fi
-    echo -e "$IMDBTAIL" >> "$IMDBLNK"
+    printf "%b\n" "$IMDBTAIL" >> "$IMDBLNK"
    fi
 
    if [ ! -z "$INFOTEMPNAME" ] && [ -e "$GLROOT$IMDBLKL/$INFOTEMPNAME" ]; then
 
 # make a file/dir with imdb info in the name 
 
-    INFOGENRES=$(echo $GENRECLEAN | tr '/ ' '\n' |  sed -e /^$/d | wc -l)
-    if [ ! $INFOGENRES -gt $INFOGENREMAX ]; then
+    INFOGENRES=$(echo "$GENRECLEAN" | tr '/ ' '\n' |  sed -e /^$/d | wc -l)
+    if [ ! "$INFOGENRES" -gt "$INFOGENREMAX" ]; then
      let INFOGENREMAXED=INFOGENRES
     else
      let INFOGENREMAXED=INFOGENREMAX
     fi
-    if [ ! $INFOGENRES -lt 1 ]; then
-     GENREFILE="$(echo $GENRECLEAN | tr '/ ' '\n' |  sed -e /^$/d | head -n $INFOGENREMAX | tr '\n' ' ' | sed "s/ /$INFOGENRESEP/g" | cut -d "$INFOGENRESEP" -f 1-$INFOGENREMAXED)"
+    if [ ! "$INFOGENRES" -lt 1 ]; then
+     GENREFILE="$(echo "$GENRECLEAN" | tr '/ ' '\n' |  sed -e /^$/d | head -n "$INFOGENREMAX" | tr '\n' ' ' | sed "s/ /$INFOGENRESEP/g" | cut -d "$INFOGENRESEP" -f 1-"$INFOGENREMAXED")"
     else
      GENREFILE="Unclassified"
     fi
-    VOTESFILE="$(echo $RATINGVOTES | tr ',' '.')"
+    VOTESFILE="$(echo "$RATINGVOTES" | tr ',' '.')"
     [[ -z "$VOTESFILE" ]] && VOTESFILE="NA"
     SCOREFILE="$RATINGSCORE"
     [[ -z "$SCOREFILE" ]] && SCOREFILE="NA"
     LIMITEDFILE="$ISLIMITED"
     [[ -z "$LIMITEDFILE" ]] && LIMITEDFILE="unknown"
-    NUMSCREENS="$(echo $BUSINESSSCREENS | tr ',' '.')"
+    NUMSCREENS="$(echo "$BUSINESSSCREENS" | tr ',' '.')"
     [[ -z "$NUMSCREENS" ]] && NUMSCREENS="unknown"
     RUNTIMEFILE="$RUNTIMECLEAN"
     [[ -z "$RUNTIMEFILE" ]] && RUNTIMEFILE="unknown"
-    INFOFILENAMEOLD="$(echo "$INFOFILENAME" | tr -c $INFOVALID $INFOCHARTO | sed "s%VOTES%*%g" | sed "s%SCORE%*%g" | sed "s%GENRE%*%g" | sed "s%RUNTIME%*%g" | sed "s%YEAR%*%g" | sed "s%ISLIMITED%*%g" | sed "s%SCREENS%*%g")"
+    INFOFILENAMEOLD="$(echo "$INFOFILENAME" | tr -c "$INFOVALID" "$INFOCHARTO" | sed "s%VOTES%*%g" | sed "s%SCORE%*%g" | sed "s%GENRE%*%g" | sed "s%RUNTIME%*%g" | sed "s%YEAR%*%g" | sed "s%ISLIMITED%*%g" | sed "s%SCREENS%*%g")"
     INFOFILENAMEOLDA="$(echo "$INFOFILENAMEOLD" | sed "s%*%.*%g")"
     INFOFILENAMEOLDB="$(echo "$INFOFILENAMEOLDA" | tr '\]\[' '.')"
     INFOFILENAMEPRINT="$(echo "$INFOFILENAME" | sed "s%VOTES%$VOTESFILE%g" | sed "s%SCORE%$SCOREFILE%g" | sed "s%GENRE%$GENREFILE%g" | sed "s%RUNTIME%$RUNTIMEFILE%g" | sed "s%YEAR%$TITLEYEAR%g" | sed "s%ISLIMITED%$LIMITEDFILE%g" | sed "s%SCREENS%$NUMSCREENS%g")"
-    INFOFILENAMEPRINT="$(echo "$INFOFILENAMEPRINT" | tr -c $INFOVALID $INFOCHARTO)"
-    if [ ! -z "$(ls -1 "$GLROOT$IMDBLKL" | grep -a -e "$INFOFILENAMEOLDB")" ]; then
-     for OLDINFOFILE in $(ls -1  "$GLROOT$IMDBLKL" | grep -a -e "$INFOFILENAMEOLDB" | tr ' ' '^'); do
-      OLDINFOFILE="$(echo $OLDINFOFILE | tr '^' ' ')"
+    INFOFILENAMEPRINT="$(echo "$INFOFILENAMEPRINT" | tr -c "$INFOVALID" "$INFOCHARTO")"
+    if [ ! -z "$(ls -1 "$GLROOT$IMDBLKL" | grep -e "$INFOFILENAMEOLDB")" ]; then
+     for OLDINFOFILE in $(ls -1  "$GLROOT$IMDBLKL" | grep -e "$INFOFILENAMEOLDB" | tr ' ' '^'); do
+      OLDINFOFILE="$(echo "$OLDINFOFILE" | tr '^' ' ')"
       rm -f "$GLROOT$IMDBLKL/$OLDINFOFILE" >/dev/null 2>&1
       rmdir "$GLROOT$IMDBLKL/$OLDINFOFILE" >/dev/null 2>&1
      done
@@ -1005,47 +921,45 @@ if [ ! -z "$RUNCONTINOUS" ] || [ -z "$RECVDARGS" ]; then
 # create a thumbnail?
 
    if [ "$DOWNLOADTHUMB" = "YES" ]; then
-    FILENAME=$(ls -1Ftr "$GLROOT$IMDBLKL" | grep -a -v "/" | grep -a -v "@" | grep -a -e "[.][nN][fF][oO]" | head -n 1)
-    TMBNAME=$(echo $FILENAME | sed "s/\.nfo/.jpg/")
+    FILENAME=$(ls -1Ftr "$GLROOT$IMDBLKL" | grep -v "/" | grep -v "@" | grep -e "[.][nN][fF][oO]" | head -n 1)
+    TMBNAME=$(echo "$FILENAME" | sed "s/\.nfo/.jpg/")
     if [ ! -z "$USEWGET" ]; then
-     wget $WGETFLAGS -U "$USERAGENT" -O $TMPFILE --timeout=30 $GLROOT$IMDBLKL/$TMBNAME >/dev/null 2>&1
+     wget "$WGETFLAGS" -U "$USERAGENT" -O "$TMPFILE" --timeout=30 "$GLROOT$IMDBLKL/$TMBNAME" >/dev/null 2>&1
     elif [ ! -z "$USECURL" ]; then
-     curl $CURLFLAGS -A "$USERAGENT" -o $TMPFILE --connect-timeout 30 $GLROOT$IMDBLKL/$TMBNAME >/dev/null 2>&1
+     curl "$CURLFLAGS" -A "$USERAGENT" -o "$TMPFILE" --connect-timeout 30 "$GLROOT$IMDBLKL/$TMBNAME" >/dev/null 2>&1
     fi
    fi
 
 # Should we run any external scripts?
 
    if [ ! -z "$EXTERNALSCRIPTNAME" ]; then
-    FILENAMED=$(ls -1Ftr "$GLROOT$IMDBLKL" | grep -a -v "/" | grep -a -v "@" | grep -a -e "[.][nN][fF][oO]" | head -n 1)
-    if [ ! -z "$FILENAMED" ]; then
-     touch -acmr "$GLROOT$IMDBLKL/$FILENAMED" "$GLROOT$IMDBLKL" >/dev/null 2>&1
-    fi
     for EXTERNALNAME in $EXTERNALSCRIPTNAME; do
-     if [ "$DEBUG" = "4" ] && [ ! -z "$(head -n 1 $EXTERNALNAME | grep -a -e "/bin/bash")" ]; then
-      bash -x -v $EXTERNALNAME "\"$DATE\" \"$IMDBLNK\" \"$IMDBLKL\" \"$IMDBDIR\" \"$IMDBURL\" \"$TITLE\" \"$GENRECLEAN\" \"$RATINGCLEAN\" \"$COUNTRYCLEAN\" \"$LANGUAGECLEAN\" \"$CERTCLEAN\" \"$RUNTIMECLEAN\" \"$DIRECTORCLEAN\" \"$BUSINESSSHORT\" \"$PREMIERE\" \"$LIMITED\" \"$RATINGVOTES\" \"$RATINGSCORE\" \"$TITLENAME\" \"$TITLEYEAR\" \"$BUSINESSSCREENS\" \"$ISLIMITED\" \"$CASTLEADNAME\" \"$CASTLEADCHAR\" \"$TAGLINECLEAN\" \"$PLOTCLEAN\" \"$RATINGBAR\" \"$CASTCLEAN\" \"$COMMENTSHORTCLEAN\" \"$COMMENTCLEAN\" \"$METACLEAN\""
+     if [ "$DEBUG" = "4" ] && [ ! -z "$(head -n 1 "$EXTERNALNAME" | grep -e "/bin/bash")" ]; then
+      bash -x -v "$EXTERNALNAME" "\"$DATE\" \"$IMDBLNK\" \"$IMDBLKL\" \"$IMDBDIR\" \"$IMDBURL\" \"$TITLE\" \"$GENRECLEAN\" \"$RATINGCLEAN\" \"$COUNTRYCLEAN\" \"$LANGUAGECLEAN\" \"$CERTCLEAN\" \"$RUNTIMECLEAN\" \"$DIRECTORCLEAN\" \"$BUSINESSSHORT\" \"$PREMIERE\" \"$LIMITED\" \"$RATINGVOTES\" \"$RATINGSCORE\" \"$TITLENAME\" \"$TITLEYEAR\" \"$BUSINESSSCREENS\" \"$ISLIMITED\" \"$CASTLEADNAME\" \"$CASTLEADCHAR\" \"$TAGLINECLEAN\" \"$PLOTCLEAN\" \"$RATINGBAR\" \"$CASTCLEAN\" \"$COMMENTSHORTCLEAN\" \"$COMMENTCLEAN\" \"$METACLEAN\""
      else
-      $EXTERNALNAME "\"$DATE\" \"$IMDBLNK\" \"$IMDBLKL\" \"$IMDBDIR\" \"$IMDBURL\" \"$TITLE\" \"$GENRECLEAN\" \"$RATINGCLEAN\" \"$COUNTRYCLEAN\" \"$LANGUAGECLEAN\" \"$CERTCLEAN\" \"$RUNTIMECLEAN\" \"$DIRECTORCLEAN\" \"$BUSINESSSHORT\" \"$PREMIERE\" \"$LIMITED\" \"$RATINGVOTES\" \"$RATINGSCORE\" \"$TITLENAME\" \"$TITLEYEAR\" \"$BUSINESSSCREENS\" \"$ISLIMITED\" \"$CASTLEADNAME\" \"$CASTLEADCHAR\" \"$TAGLINECLEAN\" \"$PLOTCLEAN\" \"$RATINGBAR\" \"$CASTCLEAN\" \"$COMMENTSHORTCLEAN\" \"$COMMENTCLEAN\" \"$METACLEAN\""
+      "$EXTERNALNAME" "\"$DATE\" \"$IMDBLNK\" \"$IMDBLKL\" \"$IMDBDIR\" \"$IMDBURL\" \"$TITLE\" \"$GENRECLEAN\" \"$RATINGCLEAN\" \"$COUNTRYCLEAN\" \"$LANGUAGECLEAN\" \"$CERTCLEAN\" \"$RUNTIMECLEAN\" \"$DIRECTORCLEAN\" \"$BUSINESSSHORT\" \"$PREMIERE\" \"$LIMITED\" \"$RATINGVOTES\" \"$RATINGSCORE\" \"$TITLENAME\" \"$TITLEYEAR\" \"$BUSINESSSCREENS\" \"$ISLIMITED\" \"$CASTLEADNAME\" \"$CASTLEADCHAR\" \"$TAGLINECLEAN\" \"$PLOTCLEAN\" \"$RATINGBAR\" \"$CASTCLEAN\" \"$COMMENTSHORTCLEAN\" \"$COMMENTCLEAN\" \"$METACLEAN\""
      fi
-    done
+     done
+    fi
+   fi
 
 # restore the releasedir's original date.
 #########################################
-    FILENAMED=$(ls -1Ftr "$GLROOT$IMDBLKL" | grep -a -v "/" | grep -a -v "@" | grep -a -e "[.][nN][fF][oO]" | head -n 1)
-    if [ ! -z "$FILENAMED" ]; then
-     touch -acmr "$GLROOT$IMDBLKL/$FILENAMED" "$GLROOT$IMDBLKL" >/dev/null 2>&1
-    fi
+   RELDIR="$GLROOT$IMDBLKL"
+   [ -d "$RELDIR" ] || RELDIR="$IMDBLKL"
+   if [ ! -z "$FIXDIRTIME" ] && [ -f "$DIRDATE_CARRIER" ] && [ -d "$RELDIR" ]; then
+    touch -r "$DIRDATE_CARRIER" "$RELDIR" >/dev/null 2>&1
+    rm -f "$DIRDATE_CARRIER" >/dev/null 2>&1
    fi
-  fi
 
 # clean up and make ready for next run.
 #######################################
 
-  grep -a -F -v "$IMDBLINE" "$IMDBLOG" > $TMPFILE
-  cat $TMPFILE > $IMDBLOG
-  > $TMPFILE
+  grep -F -v "$IMDBLINE" "$IMDBLOG" > "$TMPFILE"
+  cat "$TMPFILE" > "$IMDBLOG"
+  > "$TMPFILE"
  done
- > $TMPRESCANFILE
- > $IMDBPID
+ > "$TMPRESCANFILE"
+ > "$IMDBPID"
 fi
 exit 0

--- a/scripts/psxc-imdb/main/psxc-imdb.tcl
+++ b/scripts/psxc-imdb/main/psxc-imdb.tcl
@@ -144,7 +144,7 @@ namespace eval ::ngBot::plugin::psxc-IMDb {
         ##
         ##################################################
 
-        set psxc(VERSION) "v3.1-graphql"
+        set psxc(VERSION) "3.2"
 
         variable events [list "IMDB" "IMDBVAR" "IMDBFIND" "IMDBFINDVAR"]
         variable psxcimdb


### PR DESCRIPTION
v3.2 of the psxc-imdb suite, now running entirely from a shared library and fully compatible with both Linux and FreeBSD. GLROOT is no longer hardcoded anywhere; it comes only from psxc-imdb.conf.

Shared library (psxc-imdb-lib.sh):
- Centralizes common logic: config loading, logging, queue lookup, IMDB API requests, ID extraction, URL localization, argument parsing, pre-dirname extraction, glroot stripping, and file date handling
- All main scripts and addons source the library, eliminating duplicated code; infra defaults moved into imdb_set_defaults()

Localized IMDB URLs (LOCALURL):
- Path-based localized URLs (e.g. LOCALURL="de" -> www.imdb.com/de/title/...) replacing the retired country-specific IMDB subdomains
- Supported locales: de, fr, es, it, pt, hi; invalid values fall back to plain www.imdb.com URLs

GLROOT from psxc-imdb.conf only:
- Removes every hardcoded GLROOT=/glftpd default from the scripts; GLROOT now comes only from the sourced psxc-imdb.conf
- imdb_load_config auto-discovers the conf from the script's location ($SCRIPT_DIR/../etc/psxc-imdb.conf) or $CONFFILE, so no GLROOT default is needed to find it; fails loudly when not found (no silent /glftpd fallback)
- psxc-imdb.sh, nuker, symlink-maker, rescan and sanity load the conf via the shared imdb_load_config before any GLROOT-dependent default is evaluated; rescan also loses its fragile 'grep CONFFILE from psxc-imdb.sh' sourcing
- sanity drops the obsolete MYGLROOT/CHGLROOT host-vs-chroot split and the chroot-detection branches (single GLROOT from the conf)
- Static CONFFILE= defaults are removed from the scripts; the lib default is the single source
- installer: GLROOT defaults to /glftpd when it can't be detected from glftpd.conf; the quoted -d check forces a valid existing root
- nuker: dropped the impossible $GLROOT/glftpd.conf candidate (glftpd.conf always lives in $GLROOT/etc or /etc inside the chroot)

FIXDIRTIME (default empty):
- When set to "YES", the release dir's original mtime is preserved: a snapshot (touch -r to a temp carrier in the logs dir) is taken before any file is created in the release dir and restored afterwards, covering the dummy placeholder files, the info files, and both the success and API-error paths, so the dir date stays unchanged and upload-order dirlists stay intact (imdb-rescan -r does not rewrite scanned dirs)
- Snapshot/restore resolve the release dir and the mtime-snapshot carrier via a chroot/host fallback, so they work both chrooted and on the host
- The default "" means the script never actively touches directory timestamps - creating the .imdb/.imdbinfoname files will still bump the dir's mtime to the run time on the first pass

Cross-platform (Linux + FreeBSD):
- POSIX-compatible tools throughout (no GNU-only grep -oP/-a, echo -e, rmdir flags, ls date sorting); BSD stat -f date handling via get_file_date(); portable sed -i and LC_ALL=C tr config generation
- Installer detects required binaries (bash 4+, jq, curl) across /usr/local/bin and standard paths, with per-OS install hints
- Metacritic support added to the IMDB GraphQL pipeline (METACLEAN) and exposed via the %imdbmetacritic% token; consumed by psxc-imdb.tcl and psxc-imdb-dotimdb.pl

Addon and workflow hardening:
- Addons auto-detect their config paths (nuker, symlink-maker) in both direct and rescan-context invocations; only files needing edits are prompted for
- psxc-symlink-maker.sh creates relative symlink targets
- Missing rescan flag file handled gracefully instead of erroring

Queue processing (multiple uploads in one run):
- Per-release flags (DOTIMDB, USEBOT, EXTERNALSCRIPTNAME, INFOTEMPNAME, BOTONELINE, TRIGGER, LOGFORMAT, MYOWNFORMAT, MYOWNEMPTY, GLLOG, TAGPLOT, BOTHEAD) are snapshotted after run-level flag handling and restored at the top of each queue iteration, so an API error, a removed release dir, or a find /dev/null entry no longer leaks cleared state into the next release processed in the same run